### PR TITLE
Adds securedrop-client-0.0.8 and securedrop-proxy-0.1.4

### DIFF
--- a/workstation/stretch/securedrop-client_0.0.8_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b52d6b6e019705e912b0ee644f42c9dbded7d3c40e5a577212ed323498dd18d9
+size 4043910

--- a/workstation/stretch/securedrop-proxy_0.1.4_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea42a313d50b568ca4bee85864625cdaf709576a1a31ebfb9d7f2fa098a4945c
+size 3042806


### PR DESCRIPTION
Originally released by @creviera in
https://github.com/freedomofpress/infrastructure-deb-packages-lfs/commit/ea9705a35660c522f22662ea4ae35c4e8d565e16