### PR TITLE
Adds historical SD core packages

### DIFF
--- a/core/xenial/linux-firmware-image-4.4.167-grsec_4.4.167-grsec-1_amd64.deb
+++ b/core/xenial/linux-firmware-image-4.4.167-grsec_4.4.167-grsec-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db06a287c76538728ba2a2ea3bc157e9710358aec006301c7a059501783f614e
+size 963502

--- a/core/xenial/linux-firmware-image-4.4.177-grsec_4.4.177-grsec-1_amd64.deb
+++ b/core/xenial/linux-firmware-image-4.4.177-grsec_4.4.177-grsec-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b8219a9e292960f25aa4003091343dbd7fafb8a29507b85e199a7f33f240791
+size 962384

--- a/core/xenial/linux-firmware-image-4.4.182-grsec_4.4.182-grsec-1_amd64.deb
+++ b/core/xenial/linux-firmware-image-4.4.182-grsec_4.4.182-grsec-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79101eb69c8ccc8d546df6f5ebd2bd62d1a35aa08b6ab81fb6db84af2dfd427b
+size 962170

--- a/core/xenial/linux-image-4.4.167-grsec_4.4.167-grsec-1_amd64.deb
+++ b/core/xenial/linux-image-4.4.167-grsec_4.4.167-grsec-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5400e3392fe9165760a0bd525e478771d7ab8c384155e1947e2505582357a7b
+size 38489718

--- a/core/xenial/linux-image-4.4.177-grsec_4.4.177-grsec-1_amd64.deb
+++ b/core/xenial/linux-image-4.4.177-grsec_4.4.177-grsec-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b4b779d75c83ce7e1066e2828761c5199b28816a72630d5e364a47c2162d64c
+size 38525906

--- a/core/xenial/linux-image-4.4.182-grsec_4.4.182-grsec-1_amd64.deb
+++ b/core/xenial/linux-image-4.4.182-grsec_4.4.182-grsec-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eae3727431240d27fcd164663dbbf4df65c270040350a9ad87cb0c19a526c885
+size 38573168

--- a/core/xenial/ossec-agent-3.0.0-amd64.deb
+++ b/core/xenial/ossec-agent-3.0.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49c24f69c7431fe17db2a623f1193ee288e2b86eff6973da1ab8df6c927d0ee6
+size 369694

--- a/core/xenial/ossec-server-3.0.0-amd64.deb
+++ b/core/xenial/ossec-server-3.0.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6d49e724352929953cf16a6722a95f7baacba817fdd6bf13601657a2bc125e6
+size 726934

--- a/core/xenial/securedrop-app-code_0.13.0+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_0.13.0+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9cc3d2c61765539a8b72ed798601e0313cfed17cc789c7c19153e4871e9729d
+size 13448080

--- a/core/xenial/securedrop-app-code_0.13.1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_0.13.1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17b4bec65f3e86f1dde12497ebf6fa1ada8fc5bca790495570fdad0c6261a48d
+size 13448560

--- a/core/xenial/securedrop-config-0.1.3+0.13.0-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+0.13.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb5817c446555e02544cfde7f9b21d343255536509aa74c7cb3b10e8a555d020
+size 2920

--- a/core/xenial/securedrop-config-0.1.3+0.13.1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+0.13.1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62f35aa3199d0a124e8e396b203a0db1c8465d0010ecd12bdd4eea67fff61bd9
+size 2918

--- a/core/xenial/securedrop-grsec-4.4.167-amd64.deb
+++ b/core/xenial/securedrop-grsec-4.4.167-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa89911881b01058c78cd44855c41067649c19f0a45af2bbac9e34cb2bf69b7e
+size 1970

--- a/core/xenial/securedrop-grsec-4.4.177-amd64.deb
+++ b/core/xenial/securedrop-grsec-4.4.177-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12767a99e392d48cf7da82adb157cfaed908726103b711696a209c4ad8576923
+size 1972

--- a/core/xenial/securedrop-grsec-4.4.182-amd64.deb
+++ b/core/xenial/securedrop-grsec-4.4.182-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77e749f983174824aaf4e50d55037b2fe913ac80c4f65a9241188b40d34fb643
+size 2150

--- a/core/xenial/securedrop-keyring-0.1.2+0.13.0-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.2+0.13.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6775a8b1fd4d7bd517a46b66ebebe85ace176140b0e993b7133e43bf17970d9
+size 3630

--- a/core/xenial/securedrop-keyring-0.1.2+0.13.1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.2+0.13.1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5e1a25476366047507e8ceb7cab2dce3b11f740dbfa891891f9f435dd1492fc
+size 3636

--- a/core/xenial/securedrop-ossec-agent-3.0.0+0.13.0-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+0.13.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a45906ee652498276195be91e558401387d94548d1f6c8db66bf72cc9179db6
+size 3382

--- a/core/xenial/securedrop-ossec-agent-3.0.0+0.13.1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+0.13.1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22c96625a9a9c962076b7ed231dd9e4ee4c39b24295fd91abe5f4ab038e19964
+size 3382

--- a/core/xenial/securedrop-ossec-server-3.0.0+0.13.0-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+0.13.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7489c3ef266a7be8f71690facfcf7bd710575cc8fad4152ed2c19d477e51cd37
+size 6432

--- a/core/xenial/securedrop-ossec-server-3.0.0+0.13.1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+0.13.1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8efd3b218a57ae999f3fd3dbd65e2cc013cfa86fb4dc174f90d7e9594ac10124
+size 6436

--- a/core/xenial/tor-geoipdb_0.3.5.7-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.3.5.7-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88ccd935a58612ee05d83ff05bb820a43cad7945293604dcd481c08b7f1f6a25
+size 874412

--- a/core/xenial/tor-geoipdb_0.3.5.8-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.3.5.8-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03a7f0ea2e3308d489725eff978a0c162f3518f27cf8392b16801875069472c7
+size 908108

--- a/core/xenial/tor_0.3.5.7-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.3.5.7-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d8b5183c4ff790e67bed6344d249708a5ef3002c047d2280146794780571fb
+size 1340816

--- a/core/xenial/tor_0.3.5.8-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.3.5.8-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:659cc523a66a6a382147972c76df8796cc6d8faf69c31ed1ce4ab66b9f4d6bad
+size 1340110


### PR DESCRIPTION
Pulls in a light package history (only back to 0.13.0) for use on the new automated nightly setup for https://apt-test.freedom.press/ . These packages have already been served in prod, with the exception of the 4.4.182 kernels, which have only been published to apt-test to date, to aid in pre-release QA for 0.14.0. 

### Testing
* [ ] Confirm these are the same packages served by apt-test currently (checksums on files should match exactly)
* [ ] Confirm dir layout here is sane; trying to be future proof, but we can always shove around as necessary.