### PR TITLE
add initial securedrop-workstation-export package

### DIFF
--- a/workstation/stretch/securedrop-workstation-export_0.1.1-1_all.deb
+++ b/workstation/stretch/securedrop-workstation-export_0.1.1-1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66fbc9961e95d2b588437e73b3b2c3d2b56c620460e5f879e9a16c12b8782223
+size 4466


### PR DESCRIPTION
Adds simple (non python-module) .deb containing the send-to-usb script and associated files used by sd-export-usb.