### PR TITLE
Adds tor 0.4.0.5 deb packages

### DIFF
--- a/core/xenial/tor-geoipdb_0.4.0.5-2~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.0.5-2~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ca4e21e514bad6c567440ee9573c833d9e5f4bff8adf78a44f84b1e5beda557
+size 914280

--- a/core/xenial/tor_0.4.0.5-2~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.0.5-2~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfb7f4840b524a1cdc3a1b1f1d1c16292b073348268b579678d0ff2253e619c2
+size 1385484


### PR DESCRIPTION
The upstream tor apt repo no longer serves 0.3.x packages for Xenial, so
we're moving to the 0.4.x series. See the release schedule here:

https://trac.torproject.org/projects/tor/wiki/org/teams/NetworkTeam/CoreTorReleases

### Testing
The checksums of these files should match exactly what's available in the upstream tor repo: https://deb.torproject.org/torproject.org/pool/main/t/tor/

Meant to be reviewed in tandem with https://github.com/freedomofpress/securedrop/pull/4661
