### PR TITLE
Add SecureDrop 1.0.0-rc1 debs

### DIFF
--- a/core/xenial/securedrop-app-code_1.0.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.0.0~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88dce6d85bad33071f85c2abfba7026c0f1eae06f4c9f2bd8500b2f7c658ffb4
+size 13445290

--- a/core/xenial/securedrop-config-0.1.3+1.0.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.0.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:468576cbcbc1a1c80fb022ddb0e40ed28d4bf02fa26a2c5c44358c2860e19c11
+size 2924

--- a/core/xenial/securedrop-keyring-0.1.3+1.0.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.0.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfb5285a4ffd8e7ebe936af32ee932b40e87c35d917ebf8a656b9cb7da68fd49
+size 4742

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.0.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.0.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac57c3a1be32eb586ae60a9ed534db49922e9526b39076d68faeb53f146eb63b
+size 3390

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.0.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.0.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b76e23c70255ba1c5b51cecbb499c1a5de3059e36528c156636f0fde457c2ae7
+size 6450


### PR DESCRIPTION
Provides SecureDrop core debs build on the 1.0.0-rc1 tag.

