### PR TITLE
update tor packages to 0.4.1.5-1

### DIFF
--- a/core/xenial/tor-geoipdb_0.4.1.5-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.1.5-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7fcecedae2943c1ce92f811257dff071240dc7ea608a933f648ffdc2815bc2e
+size 942954

--- a/core/xenial/tor_0.4.1.5-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.1.5-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b191ac3091563fc0acb433c58ef41de4f5560b7be25c93ed11a972e14424865a
+size 1414256


### PR DESCRIPTION
Updating tor packages after this PR from core was merged: https://github.com/freedomofpress/securedrop/pull/4728