### PR TITLE
Add securedrop-core packages for 1.1.0-rc1, purge old securedrop-workstation packages

### DIFF
--- a/core/xenial/ossec-agent-3.0.0-amd64.deb
+++ b/core/xenial/ossec-agent-3.0.0-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1a8eec6c4333f4333a501279edf85b83ded5657ed357d2c68e225f7cbe51bbc
-size 370084
+oid sha256:f0835ada85ac89c5aaed5e1658addc652fa6ce1adc6adf07a13b794e470aeb1c
+size 369760

--- a/core/xenial/ossec-server-3.0.0-amd64.deb
+++ b/core/xenial/ossec-server-3.0.0-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9aae22626083b9d1860b027ff72c4e282567a4eb22e4e2ee7d12f68f0ae09f8
-size 730316
+oid sha256:29fbab5ea941cde21b78c505492edc7b86ee8b50a65ef9c7687be183e5bf1083
+size 727108

--- a/core/xenial/securedrop-app-code_1.1.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.1.0~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:406719f7dcd17186a8e6721ed146d97d55634329b5d89adf8605adfaa0d767d1
+size 12488564

--- a/core/xenial/securedrop-config-0.1.3+1.1.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.1.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d9b523f4e41c1f2f816b9b7b9b6a1e8787ba5d4f69f383a81f523ff1e412a00
+size 2736

--- a/core/xenial/securedrop-grsec-4.4.182-amd64.deb
+++ b/core/xenial/securedrop-grsec-4.4.182-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfd46b89a186b79c65eee90075a026e2c9c73a37c09335fea55a39b2124380ef
-size 2150
+oid sha256:6729306c54067834b53669f37053dd1d8e5d5d8c63068bbe2c2803a2aa05f91e
+size 2146

--- a/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3fa968a76c1014f57e02d6ce3524377353ffce6513b3ce8015b3c4693e1aa2d
+size 4748

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b3eac4d214ef902597d1bff580b10e714d286bbd382773a51ae66c98a79732b
+size 3588

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe1e1004659d545a39b90d4066637a3008418c190b850705027175e504cc333f
+size 6640

--- a/core/xenial/tor-geoipdb_0.4.1.6-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.1.6-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1ef9e7b19aaa5156cc3bd0274bf324038bb003511305f7c094caa824b2f0b43
+size 946014

--- a/core/xenial/tor_0.4.1.6-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.1.6-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91fa752dc355e6c0b544ed6221c8c90823a76500dd21c2244f5965eff1015b01
+size 1422370

--- a/workstation/stretch/securedrop-client_0.0.7_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.7_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da97d1c881f481526aa83708df8daff519958783d98b7543ed688295debe044e
-size 5384168

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190628-003134_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190628-003134_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07f8f5c3d9995fbcf966a8449d61a92e7e1ac7b9048333fa092be2eda68c8d96
-size 4042758

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190711-050213_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190711-050213_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73cfc8ef4107db0d304468cc74a343d473ebc0f1784096288ec19b7b4a326201
-size 4046150

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190712-050227_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190712-050227_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:335a347385c640a596bd3ba4445768226ff08d742830ce221d3e95c4744b70aa
-size 4045630

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190713-050213_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190713-050213_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dd53a3601c74d95748b78a3517a5a27e9056a0b2f0ebc4f4d1d54b618b79068
-size 4045674

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190714-050206_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190714-050206_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4957718338483d85f1cdafc961ff20ee150e1a5d6476adb2ac758393e53097e1
-size 4045950

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190715-050224_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190715-050224_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d84a6c2b4c9356e7c4967aec0adc0df9c21990a248e8a63f3f019760f8fee78
-size 4045512

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190716-050224_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190716-050224_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84cccbaae7c1c0e8fb89015188ac9fdf8e0130244d3b97d3079144932ea0a11c
-size 4047106

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190717-050223_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190717-050223_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9aa9f125f06a043d388ce450b7a79f5705e526cd86beb7c2a53b186256ae165f
-size 4045810

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190718-050227_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190718-050227_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84d1da1b0a6520f49c19a83c75fcddeb2e7a081392d4cd2c7ab76ea0a3236de4
-size 4045680

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190719-050228_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190719-050228_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c8e6ad8e7c3d2c390d1091f110f680ac0e645a24ea6ddcad94d4d98efc12d32
-size 4045360

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190720-050213_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190720-050213_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8e783bb7bbdbff6988476c0fe2c9a637f5eeb55d2837678250a26f6e713f180
-size 4046970

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190721-050234_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190721-050234_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c06a3b3ee0919e4fc972c2e69a270cbaf590a51edbe3fdcc605de4b4a210e371
-size 4047102

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190722-050407_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190722-050407_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fd889d5c4672b16b7a040c336f7ae9bdcd72a07eb08f812f1e49710327e1e22
-size 4046250

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190723-050237_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190723-050237_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac212d1b1c02ce7f6ed1573e631f07f0628a5bc0a24d89de64c401b703c196f7
-size 4047238

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190724-050237_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190724-050237_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d6b47aaab6053572dc53919b6359593d12f25a3b77948086e63315b6ab5a56e
-size 4080036

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190725-050258_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190725-050258_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6e65babf5fdf873f9e994006ceb7449ad43e11f5a0c06689e6438fd2d4a041a
-size 4079660

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190726-050227_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190726-050227_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3622c9c036dd7601bb438b48aa701b9abce2a5b154491c08c161c7e8c9553231
-size 4080960

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190727-050241_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190727-050241_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbd208f3f913885208971d3ec387b6740de6d2ec570215a7648c371ac1eb2d18
-size 4079804

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190728-050513_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190728-050513_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b11aad3ce503d3b9f1dc7e451a4285e8e0f2d39bf4db698097f10a98664f0f13
-size 4080446

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190729-050245_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190729-050245_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4177900af28cc144e2e088b1de6172f47b62fca9ed277be7745a688125740496
-size 4080330

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190730-050224_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190730-050224_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1356941b4e58565777290d42e9fbfe216f50d2c95d474a6221dd1ffb6f07d2e1
-size 4081002

--- a/workstation/stretch/securedrop-client_0.0.8-dev-20190731-050239_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8-dev-20190731-050239_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b13249f5fa3e5e49bccebaa135cd2e5007557f39b3b695f676a847d39beaf59
-size 5566676

--- a/workstation/stretch/securedrop-client_0.0.8_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.8_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b52d6b6e019705e912b0ee644f42c9dbded7d3c40e5a577212ed323498dd18d9
-size 4043910

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190731-160358_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190731-160358_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c35bc305ee1ef063613399cf8a1a502b0aa2d87f2670ade3fe07682a5368aa37
-size 5566930

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190801-050226_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190801-050226_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:684781bb5032c6153e7a59725caf0d4ca8663d048240feb3d22b6fcbcab77526
-size 5569486

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190802-050307_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190802-050307_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6087825103a3ca90a1b4091d89d0f3508a250e21bac13f5a4b900bc822a9e86f
-size 5569180

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190803-050254_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190803-050254_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68b78ede1e63af908e700d7bece6d22f800f5ea0b1063a66be26f1b2c3631b88
-size 5569854

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190804-050225_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190804-050225_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb9fcdf50fed005c8911ab68fe6ab5003126ed27f59ea6702e49c585737beca9
-size 5569100

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190805-050237_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190805-050237_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fc0eedc2fd3b883c42e6c428ce171ae9c05074ab1b1147ef6f192827850cd6a
-size 5567986

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190806-050249_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190806-050249_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87bc1cf89044d4833451c3b62bb4f34b090fc813d7dbad54bbd98eb44e2c9cb6
-size 5569758

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190807-050248_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190807-050248_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abcc8cc78a5cca34cbde36ace0193e07db269739047e65643217a39a9cb61798
-size 5570938

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190808-050320_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190808-050320_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10f945326143c77bbe3ee0ff2e59751ab053f1fec68ba6400aff835e85f69602
-size 5570934

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190809-050233_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190809-050233_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fce55c2dbd72701c7207cfd407b50afcabd2f48ec30c636850ba99624eea27b8
-size 5569960

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190810-050249_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190810-050249_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b10d577de889ba6591ae05b964a467b6d610fd7ffe6b1fda9a92694dda64a5d
-size 5570852

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190811-050414_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190811-050414_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2bd44644aa3f3f26555fd359c98b3717928015ae677aafc94585b63109d935a
-size 5572374

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190812-050435_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190812-050435_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:959c037ff5fadf4ba3b8b00fff932b443fa420484ce1882e991fd27b69b96eec
-size 5569998

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190813-050253_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190813-050253_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dcd11c7356b018cc3b54fd01b257cb358508487521e66d02040e38906f88fc3
-size 5654096

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190814-050317_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190814-050317_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:080b32dea25f000eacc1512a9c7821c2e5d2fb94bece99c66779dd9f98dfdab0
-size 5654182

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190904-060528_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190904-060528_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb8c129e634dbd44241ac1979f547ada628b354aa44b8be3867e40b1f1404618
-size 5654996

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190905-060603_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190905-060603_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8b485b719c2fc164506dd34dacf2e211833584d779748241b118b22d4c78f77
-size 5654500

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190906-060537_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190906-060537_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35773b780f6dfbd82a95a6c8d989c6043be126a8dd03915f5effc0f48a6d72c5
-size 5655272

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190907-060546_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190907-060546_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb2b11f8c00324a1da4a1c89cf7aef804609f318d06d5954ec05213198816e57
-size 5655228

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190908-060537_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190908-060537_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7291591e3a492fcc71582ea4e826336abac85894ab2df6a5b8811f6c07799e5a
-size 5654880

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190909-060536_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190909-060536_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aae004e1243db14506e04fe06f35aeb4f83b347e7575a7e5c2413239cceddd6b
-size 5655254

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190910-060609_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190910-060609_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05420474827929ece229d203edd1e1fb736c17359e74f1c2da648c4a782b019b
-size 5655802

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190911-060548_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190911-060548_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d0b7782b6b7ab98811e3209d70d2386e0334564d7ecb80114db0029507f70b9
-size 5655620

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190912-060614_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190912-060614_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:149f02bfdcfb84262bb6d0bf6ffab5c1c38e2d2d0157f426cd8de696f1dc421d
-size 5655282

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190913-060553_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190913-060553_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24377e041f54832e673a84e920651034d7f35a15371ccdc0db926ffe7dee049b
-size 5655502

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190914-060533_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190914-060533_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f23dd41e1ee04ffd43e839e15a6c4e37f99b06cbec2ea1dc3ff7ec3bdc0e77e1
-size 5655658

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190915-060536_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190915-060536_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5df1032f8a47c3d45db134ec1eefc5eff6eee40641804eb719860556caf57322
-size 5654800

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190916-060604_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190916-060604_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c96067194f4ccfd3db30ffd8b60fe088225e34f46646f61dd07f82ffe7ccdf02
-size 5654678

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190917-060540_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190917-060540_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02a37093b2cc3a4a79e71bc2a5a3f8f8ef913f4cf5ec0fbc35776142b58c8cbc
-size 5656188

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190918-060540_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190918-060540_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46620bdcc44bc61a92034bf2a0bbe600fc8b79f259cc8fafc2c993b0100c55d6
-size 5654476

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190919-060606_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190919-060606_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f4dddc25d507b6482eb7aff1c9d0cc3d83a26256996b7c7192101e595a43afe
-size 5655014

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190920-060544_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190920-060544_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1280623291a0b10dece7230d725a8a48468bfe2e730614f558d044645b91e1b0
-size 5654828

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190921-060538_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190921-060538_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c50cb7917a671d93995134cb535b6f36fa9260114f3672956517012b60e1fbc
-size 5656150

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190922-060616_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190922-060616_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f2c7e3ae3bb7ff2ca3501259807a8aa1af2dfc59b1ca503c39889a83901f1fe
-size 5655616

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190923-060539_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190923-060539_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73e28010284a9566b7311cb501c1e5c4c64bde7e4804a26054e280c5d75ee272
-size 5655964

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190924-060548_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190924-060548_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a802c22b07710fe9a607475034039507760ca76ad009180b57719ff789e2a18
-size 5657626

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190925-060539_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190925-060539_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f14f3f9b6bffdb1e7dc6f46d0cf40c94517f5dcf7da2f174e7569da32916db30
-size 5658130

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190926-060552_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190926-060552_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:903264967ff6f6cf72c6dcd7525abeb046e556ec5ec0782164f36afe10763c96
-size 5657410

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190927-060550_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190927-060550_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd85671560b2de4b4d5da8f0978b8303e46a2b786af00977b641c8b802fb5787
-size 5657452

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190928-060527_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190928-060527_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01fedbe0d042ce3d2c2584c340555cb8c5924860d77ddd4062440e791f608d9f
-size 5658252

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190929-060610_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190929-060610_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a61c6a57bb57e19fac853e023d0d11e25e41e3e8c7ee5a0721b303a9ac405e62
-size 5658260

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20190930-060550_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20190930-060550_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:920eaa94fda3885394242dfa88877b54045f15aa7c66c4da3be4e1cb0f3e2529
-size 5658362

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190725-140625_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190725-140625_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82e775acc896510bc50c02386e3c6b2fcdbdb2efcf1863e4bf5788bd8d9a5f1d
-size 2768820

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190726-050424_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190726-050424_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad64ba2a6abae83085979e7fc57720cca874dce20199a59c46d95de7073f4658
-size 2768664

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190727-050437_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190727-050437_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c401b9490aa2233cf1dfd54abb8ab27a0337b13ae8ec018f477252a08331105
-size 2769536

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190728-050924_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190728-050924_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7b14db51307a483a744728d456225ff0ba774eba069b302531d1858de35788b
-size 2769368

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190729-050439_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190729-050439_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37084dcd00d2653cff820d3abb77b16bacefc07072cd3f99cdfd8a15a55f0f94
-size 2772130

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190730-050411_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190730-050411_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:639707020daee2747f0bfcb33c3e16a8ba084638c2180301b25da457133816a7
-size 2769846

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190731-050429_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190731-050429_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26a3f581a2af0ac18544ed775b94205893e5e59a9a09f35ece5ec12948e0204e
-size 2768924

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190731-160554_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190731-160554_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b479935d8d322c8f07fd9adfd2d125b265d7dc0252224da35c93d96e2ab35741
-size 2769380

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190801-050416_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190801-050416_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:893b8a6c13590d1abcf61641d4250da974e79229ffc6faa73cc4b864fe750acb
-size 2769300

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190802-050507_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190802-050507_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61509f1c1057ff1ff17dd85324e75dad4e42b15bf981d1141d2e052cc9ceedc6
-size 2770036

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190803-050448_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190803-050448_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0881057418b82115fde74735c1afb66333c83302241897c5f14a9383caa05e46
-size 2768862

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190804-050642_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190804-050642_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97e102a6485a0962a33fc81504a1af81d752f7c69f93f7e42d53dbc0402070be
-size 2769276

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190805-050526_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190805-050526_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f0cfb128e58e2a5a36961ef37c697fe26b68cf497d4c8e99e72b8cdb362866a
-size 2769038

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190806-050456_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190806-050456_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8399a2ca0d91cb82f08a1f39cd360557423f1d9ca1cc27eda62f3d48b3b0ee1f
-size 2769154

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190807-050453_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190807-050453_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afa6c996e91eed51cf01a8759a93e5c901a55d39e0d3f7a128e51527df1f47a1
-size 2769556

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190808-050506_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190808-050506_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5bac81ff9ae145bcd6492abdbae5b42ada2da58fe98ee3c419ea9666e56d1f4
-size 2770048

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190809-050421_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190809-050421_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8365825b3b68b12f4e9d90c708c2abdfc2562d06fd4ac92f886cff0eed284120
-size 2769696

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190810-050436_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190810-050436_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b59ffd6549726ad23c90f6c847ef5a26e7af512587ecc523217f92448b1c685
-size 2769498

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190811-050602_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190811-050602_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c86c53c4baecd21814874f22185158e817f3b98c11e0933a6d2d20083e1876de
-size 2770450

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190812-050657_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190812-050657_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fba594a4c62b5a14c3ea8a850c058b0e382a871a7e3b45c19f47a32e738bbbb2
-size 2769002

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190813-050459_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190813-050459_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3733c80f0df985090364227c8729410d5356a12172f9631ad23ae07e5e644aa
-size 2769208

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190814-050522_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190814-050522_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3805daa017a6bbc3507bbcf9e8cb51a463e5fb9243bf77623bbb40089fa34cfb
-size 2770146

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190904-060725_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190904-060725_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5cdc2dbaceb5e8ef80f37d33f13b23cf47ad60f45cc5d23902a7e4cc722ab782
-size 2770740

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190905-060811_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190905-060811_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e10df49202dfe4d9a7e4d4203a69e5f7944784c4128f0917aa5d8d4192ed4c8a
-size 2769838

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190906-060736_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190906-060736_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6d191d295e474d2b023dba2f93c03f1e40225669f310b68db521d59aa7e8442
-size 2770194

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190907-060838_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190907-060838_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5d6c2b48bb7fd72a91af8e2e986fbb98eb574ab50b03d5b5ee9f9838c351b07
-size 2769910

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190908-060726_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190908-060726_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:22ff0edb3023b584414becefa60f3622271f6a2a6b3e6e6dc3a348af093fff30
-size 2769594

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190909-060733_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190909-060733_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bff1ffc79ad078e8b53aab1ebe6b54f245a211112343742edc5bba0240f35468
-size 2770538

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190910-060817_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190910-060817_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94a7b1b9ff21f41f0f3c7e952e3681bf08cb2bedf6429d83f3b226b51f3e4380
-size 2770862

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190911-060739_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190911-060739_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df081590dce039f30ec20f5a82577eeff70b37f8e767cb58ae392d4d857c4096
-size 2771678

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190912-060813_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190912-060813_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c55e47cc4a1d53f847228181770acd5bb485538a2b37752ef23ccc7c72b3cb93
-size 2771388

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190913-060756_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190913-060756_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8432dbb1dc0326d633d639c5d9d08af39502ea923f9fd59023d27defcfcaa30b
-size 2772296

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190914-060742_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190914-060742_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcb9e542c295ba09ffd581b5329dd69b78b17f0be33ba15a23a92c73bebdde14
-size 2771842

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190915-060725_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190915-060725_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebcc80fa0c66d2853315bee145542a3ff2f9eabf1c957235b4fa30dbbe7ea5bb
-size 2771068

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190916-060811_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190916-060811_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d6b3bd749651ce88dd65c2544222b06082e642d909456a439abef8f967f1c24
-size 2771060

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190917-060756_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190917-060756_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c6d898ed68a1e6305582140d4ed1c75f09a2bb9326fd6ac4e3e00336a4f461b
-size 2771292

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190918-060759_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190918-060759_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64a8b0bf7a264eb0fb03c8fed712070ece14c92d9795260137b029cd9e08e174
-size 2771414

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190919-060807_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190919-060807_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:522b3454878f200140a9c4b58b8c9f7e71c336af3230904326fa56526ac13cd9
-size 2771810

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190920-060752_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190920-060752_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05ada44783ef1f2e72f584d03df5e11b0fa5986f50561d0b826bc52c5a88fc0a
-size 2771246

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190921-060728_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190921-060728_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ddbd6763cba7c58f185f6be8281d523f3e2d34bcfe8436850318109728bf144
-size 2771074

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190922-060809_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190922-060809_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6ad3307780dc525e5fe52924dfea476d7117b07f4b84c964f44bb052dae4da8
-size 2770796

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190923-060736_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190923-060736_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bae6992bc8ce7ed600674f2c2d80b4957a876df9b9b6814fc2ff521c6e3e44b
-size 2771862

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190924-060808_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190924-060808_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d566f6fb7275001ad3d2818b597934373c94fed30ffe98c958c1f03d961c45df
-size 2771454

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190925-060752_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190925-060752_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b63a0f04a53afcce4a15b4d9086c25c8dd46d967a0afbc6e17a82c72a4edc131
-size 2771316

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190926-060752_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190926-060752_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0a5cfd692ff59cabc43826ffbaa54fc40f4042bb09d2be740bb464cf9f71dfa
-size 2771482

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190927-060818_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190927-060818_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47561e6d88e76eda3b85e8b4b0e5ffafe5ec02def8647aaa02dba7523a78b226
-size 2771164

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190928-060719_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190928-060719_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f001d47877eb3734511218c1befc5893bdb3c7089920535414ebc48a4e0f4e2
-size 2770908

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190929-060803_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190929-060803_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ed0ee12c1989da1576985cba5b5e2cfb52a81370c7b21a11e215d33f18b71c9
-size 2772356

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20190930-060743_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20190930-060743_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86b04a075c137cde1b6323e576b8359cadb03f7a7339fca1e272567fdb4f925d
-size 2771894

--- a/workstation/stretch/securedrop-proxy_0.1.3_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.3_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b8fe5e99d80e08f788cc75ebee11977f98ab3d08ec8c5de75d9212641646e02
-size 3040386

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190628-003010_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190628-003010_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0af0ae5ad5e9d161f57f914790ecb819ea604eaafb93b51dd472675ca0180268
-size 3042360

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190711-050100_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190711-050100_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e32501e6bacc94392d061e36173b7d8cad548f3f778005424c1b4b45e813cf5f
-size 3042974

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190712-050105_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190712-050105_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2adc486104eb675ff4d280dccb00227a6455ca23cff2fe33c12bb8705d54ce2c
-size 3043916

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190713-050048_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190713-050048_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e922cfba83f77040913749b6b8b091cc836b93afa2d5cc65a8e91fea8cbd63e8
-size 3043072

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190714-050040_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190714-050040_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb4de885785a6c55d339e434d8c3167342ca63717543166ea6a7cf208b90a844
-size 3042392

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190715-050059_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190715-050059_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f888c99719ab366d68e71aeaa729a1f90aaa1e5f2bbaac0a9e2e0b1a4f6824a3
-size 3043450

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190716-050054_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190716-050054_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d744ebe4d16b39b77c1d3d636fe6329d1d2edd8ce4c644fb10426338bfdda658
-size 3043012

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190717-050046_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190717-050046_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:671fa0d309b3fcc751b5bf7500484def39e7ee2c5079e6704efbdc8d504edf03
-size 3043114

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190718-050109_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190718-050109_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae8c201ae94d411f02256f00e46bef90c3d411cfe25b11a57c42e652e1516a24
-size 3043852

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190719-050056_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190719-050056_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a14971cbd26eca8ed2a89b4fdc18dd45d1eac6252c8f109a087746087af095f4
-size 3042664

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190720-050049_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190720-050049_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:128a2e55e217fe153b621624b8d1df81c013b831159fef65c4d06964376f8100
-size 3043808

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190721-050107_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190721-050107_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b123fad2465de24b9f02bb6d27be024a1117fc88eb45e7d34698830e9dbc3e4
-size 3043860

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190722-050222_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190722-050222_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed8b8ae5008081dc73587f287912007b6b4ac373c9a17ce2e1e49930f6cd3d66
-size 3044132

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190723-050108_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190723-050108_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ade5f6525d8f44775c1053033927e85f7a06b4170c2b0e03f954e0d1839d5db9
-size 3042892

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190724-050109_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190724-050109_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e995fb0e53ffcaefb1647817e28fc75163e14e5ccda4e9374b53b56ecd99e436
-size 3075954

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190725-050109_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190725-050109_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f71233d068b5dfec00056144f260095ecfaa0df5ca1efc35f35e58ed603d7c3f
-size 3076348

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190726-050046_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190726-050046_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bdad7387dad60357be229828edb96dfd68fff9da988da34d44284dc32eb723d7
-size 3076754

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190727-050049_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190727-050049_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df97d7f23fc93db73723f63e1fd6fe9e65ff61ddde61d1da52dbb4e0597cf949
-size 3075956

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190728-050306_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190728-050306_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67bf6b2f1d024bfd71c8e4ecf8637a6d45b4926430baec8217d11c51239192a6
-size 3076646

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190729-050054_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190729-050054_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4cf6250933207e8a364f764b37d0b648bf86ec01328ceb9f3291a2247178ed3
-size 3076758

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190730-050048_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190730-050048_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64b94f968aaeb4aad16dc2a87aff2484079d99b5343c01ad943500efc3cec0cc
-size 3076106

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190731-050106_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190731-050106_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:475ba8b028a61e00dc74d783fe9b3b953a998d2dd3638b25a60c2d9f9c3a3deb
-size 3076536

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190731-160209_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190731-160209_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3113fa91edaf43684e117f571d8c451ce30ac0639fab2e9cd521a66ca57124de
-size 3077066

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190801-050049_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190801-050049_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d86b0ce0225f704ecaf430584807cd5cda49dac97172a3d97d72d256c9943400
-size 3076310

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190802-050123_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190802-050123_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a9108521dd3b5bf8ffa5918f0c4433f07cc8d6e8cdd127ab73aae6ec094d2fd
-size 3076448

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190803-050108_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190803-050108_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6bc3598110a3ed427a35cffd4480255a846bb4a02c7d3b017b8e2cc16fbc451
-size 3076328

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190804-050055_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190804-050055_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c28e38bdaa5cab2a219f8972e878ef566c1befc8acbb46ce0f37e5fadad3c62
-size 3076466

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190805-050100_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190805-050100_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffe0fdbda7eae0ae94d86eb03ceb0dc4bdcfbc5b88d186639c6dedf0f49516f3
-size 3075620

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190806-050051_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190806-050051_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4efb3eee7141c3d21881d232c8fc4aa949cd1dfb7f4afe4ea1115ee5aff6f5fd
-size 3076022

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190807-050056_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190807-050056_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:072a0679f71d82c2f460d80e851f8c44ed961b549388aba6bf927f3ec0889eb3
-size 3076578

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190808-050129_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190808-050129_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19e54013baddddbc4c963a2956d70bb78e9a3450d53f4d1f3d545048e2dfdcc5
-size 3075968

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190809-050052_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190809-050052_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57398bf38a3802f906abaf987a2580cccfe74aa5ee91d44073eeb41b5c3a27a8
-size 3077234

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190810-050056_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190810-050056_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c86abfd48f21e4ed2d0f265fa23596a34392089e2f27e677e159b444e5993ca9
-size 3076442

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190811-050212_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190811-050212_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:586b37d252f2bb33a41c48c6e99f0aa931024bcd970027aa11d0f1a80bcc1c6e
-size 3076804

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190812-050058_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190812-050058_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4e5d6bcf52ac07a25ae4e32fa03e86dbf02549ea4becbb38cbf206d9bab6d87
-size 3076562

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190813-050106_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190813-050106_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6998f25fbf4e48f68dbb7ac6544cabf5ebd504da0f9ddcac5f41c71283abe2b7
-size 3076706

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190814-050122_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190814-050122_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d565507b6ef62e9547d8a13332df9e8dfa50e539cd7016a7e5f015a22f177a16
-size 3075442

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190904-060343_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190904-060343_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b25674760899bacb31974706d5de68e093ede6878bebb901cacf61a9a7b6da3
-size 3076296

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190905-060352_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190905-060352_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72c0285535fa3a7b76936ad34e473d9a70a6297bcab3f1fa52d0a5a39f05ced7
-size 3077446

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190906-060353_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190906-060353_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e788c9cad882b89c86bd7fecd93b9e0dfea8896672834b97f10ada8c48789ca7
-size 3076046

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190907-060338_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190907-060338_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c70c77bef1c363722b1a5cf9024fe26c9b67551bca34b17ed5393aa6bd67d27
-size 3076270

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190908-060350_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190908-060350_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5756423805af952fae863b4e5a2eff01cf8ed01b521219a322981d13ffb2d91e
-size 3076164

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190909-060342_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190909-060342_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0883b8a1b9325a35cc33452addd79d59e67e7cfd2215387a6882779fc1ea3c9d
-size 3076234

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190910-060410_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190910-060410_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6959643ced1ab3640a01f8a262c54e3f88ab1c1741b8b6936ca14a4509efff6f
-size 3078538

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190911-060344_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190911-060344_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3fe6bd80adcc43b6b01b27c198087723b55e76c9f125db763896ef86e16682c
-size 3076738

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190912-060358_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190912-060358_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df4e4c19babbfc630ccc9ced7378ccdea0ddbcfe56fae9576481f9cbb7f7ecd1
-size 3077682

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190913-060352_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190913-060352_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e3af00994135d3042e31580bbab0a4f594eee8e370404a5d45020dcdc975a07
-size 3077092

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190914-060337_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190914-060337_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01bd822460751239a6bda03ddc8a4b698711c592183b0e67d8edc71a6b616649
-size 3075902

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190915-060349_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190915-060349_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3236a6a50560032cad01f90240942112f15ff651f36567d2a48d5e03dc0c60b
-size 3076198

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190916-060358_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190916-060358_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a452aceccfa2d1c8621a3ef42ed0a5304d9e4e43de80f4a8a5282e1df31972f
-size 3076578

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190917-060342_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190917-060342_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a194b0f2590fa69ddf646dc5853611cd5eaede60f72f2f71f332e76722b3eb42
-size 3075720

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190918-060343_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190918-060343_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02373bf9e94c5563083d53309469f1e239aa1cb6cf02ed5928f4ed32dbc903c0
-size 3077496

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190919-060400_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190919-060400_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91a9f023822326f399895bebfefe92fc25f19201cd25dda2b78e33bbfa51c70c
-size 3075972

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190920-060343_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190920-060343_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d175bb1f70804854ece3824bdbfac7c707514e0460fd1a58c2654425a0bc218a
-size 3075964

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190921-060342_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190921-060342_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e88aae7b53cbe0f8615b3e595eac2d7e04ffd0751ba8b41f5e265f5d841c0f4
-size 3076654

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190922-060423_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190922-060423_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6949fe3651a68b0e755a4c5bee648e1d62570ce6852ee1eebdc536dddbc3233b
-size 3076312

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190923-060345_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190923-060345_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8133010e9c481dd992cb5b8e70420e896a30afb9a0cc46ce73620b007f072b0
-size 3076594

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190924-060345_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190924-060345_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05d12ae1525fa024b6d34bc799a38f05f761a600c986716e74dd04379c5e81e3
-size 3076084

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190925-060343_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190925-060343_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da1c67781b4c94ba8d7f28c15e42448088dcc3af5a727ef7dea6e4807611fc79
-size 3076212

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190926-060348_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190926-060348_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c497260c3c20ada77b108c679b98c6721733c1b4143d4e88da87723e0e85e2a
-size 3076454

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190927-060344_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190927-060344_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e6fb4dcc2f7be30282d1472d6dd15a1196caac35fa45c7dce989a3a7891e9f2
-size 3077160

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190928-060339_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190928-060339_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:849430701f44f8149fde5c4223194fef620ffbda2518031f7f8646ff196adb38
-size 3076528

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190929-060412_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190929-060412_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:daf595f2a4fd469091f6ccdd4b8bdaca98fa86b754d82bf981de8b0423cbe600
-size 3077044

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20190930-060344_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20190930-060344_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:815fe13963549e0adf63ce62b868f2ed9e959467e70aa3e048e783a0e189f442
-size 3076626

--- a/workstation/stretch/securedrop-proxy_0.1.4_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea42a313d50b568ca4bee85864625cdaf709576a1a31ebfb9d7f2fa098a4945c
-size 3042806


### PR DESCRIPTION
* SecureDrop workstation packages for July, August and September have been removed
* SecureDrop core 1.1.0-rc1 packages built on 1.1.0-rc1 tag
* Added Tor 4.1.6 (from https://github.com/freedomofpress/securedrop/pull/4889/commits which will be cherry-picked into 1.1.0)

Build logs can be found here: https://github.com/freedomofpress/build-logs/commit/e42d5bfdafed57b45be8db0a5b11c84eaee2b326
