### PR TITLE
SecureDrop 1.1.0-rc2

### DIFF
--- a/core/xenial/securedrop-app-code_1.1.0~rc2+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.1.0~rc2+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:692744c598b22bb49e22df427c294932e51aa016a808c2a385e653385672e5f4
+size 12500008

--- a/core/xenial/securedrop-config-0.1.3+1.1.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.1.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28fb55256c3d67a1b828aa3543f868aca9cb0c9d1061ef741f0f58c07caa6603
+size 2734

--- a/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00d25d5fe64f78884980e50d5de8471f99b9e1fbfe806b8f82d1ba76b4a012ef
+size 4750

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516eaeec30338b0b1fd584fd407fc88d7bb2639f5e44efaab04d70effbbbedb8
+size 3586

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16ca25a5b1a9d39e2b74eccda87779c2046286f09d3c44a7d7a1d353a2b607c5
+size 6652


### PR DESCRIPTION

Build logs can be found here: https://github.com/freedomofpress/build-logs/commit/2c9c84947340da1ba3c76c82451ef697df2d7863