### PR TITLE
Add securedrop 1.1.0-rc4 debs

### DIFF
--- a/core/xenial/ossec-agent-3.0.0-amd64.deb
+++ b/core/xenial/ossec-agent-3.0.0-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3fc16c7035d1dcde723e11f31967b769b8e2ef565b7fba301d8671b4691f130
-size 369548
+oid sha256:f0835ada85ac89c5aaed5e1658addc652fa6ce1adc6adf07a13b794e470aeb1c
+size 369760

--- a/core/xenial/ossec-server-3.0.0-amd64.deb
+++ b/core/xenial/ossec-server-3.0.0-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd700b4a9d7fc936b524014d81c3d5bf9db2a6caaa48f9ed52e6d9279b29474b
-size 727508
+oid sha256:29fbab5ea941cde21b78c505492edc7b86ee8b50a65ef9c7687be183e5bf1083
+size 727108

--- a/core/xenial/securedrop-app-code_1.1.0~rc4+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.1.0~rc4+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f1fad9d3c1b692fe77bacc7ee4057e0656b7cac5fd0f6e960cb6671c68ac940
+size 12498748

--- a/core/xenial/securedrop-config-0.1.3+1.1.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.1.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b0351c3ec834a9a375ddee05577b248620e521d944a2cfc629014b6ba894756
+size 2736

--- a/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8de71e1d54f3035dc36ff28a1d1495fd2a38ffe1392c835c1efe03227d7eab3d
+size 4750

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db49a10388eccc2a59d03348c92ee602230a90c0d8860fd08f13f3c6012f8bfa
+size 3588

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00f819e518ae56d836c0351e98cc1c1126be1ac255923fc1d1c3e993bbf4170
+size 6640


### PR DESCRIPTION
Also reverted ossec-{agent,server}-3.0.0-amd64.deb to their previous version per our conversation in standup today.

Build logs here: https://github.com/freedomofpress/build-logs/commit/9f633b7022f2c1dca8b5269d33ecdf60104ab55c
