### PR TITLE
SecureDrop 1.1.0-rc5

### DIFF
--- a/core/xenial/securedrop-app-code_1.1.0~rc5+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.1.0~rc5+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d8f8350e810c9510e6a6cba43dbeca06526c7e553a4cd1a17cf7670921eac5e
+size 12506780

--- a/core/xenial/securedrop-config-0.1.3+1.1.0~rc5-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.1.0~rc5-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec3752bb1f2024edaca9802d1eaa9e408e78140bd342d02f46f785c6e62e5531
+size 2734

--- a/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc5-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.1.0~rc5-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ca32bcb99367bc2bbca4be82024e661fece374256507ed0031d69013d78dd5f
+size 4752

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc5-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.1.0~rc5-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2884094ac0a8be442c4f1e5e71046377b06a93bd0d6669c334c44a39b6cc231
+size 3592

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc5-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.1.0~rc5-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fabf8b956f221b578b725cb75a67e51d735a83f379dfffb33c8f4deaecad9497
+size 6644


### PR DESCRIPTION
- Debs built on https://github.com/freedomofpress/securedrop/tree/1.1.0-rc5
- Logs can be found https://github.com/freedomofpress/build-logs/commit/53526164ecf18bdf31261b45f0a98427f968097c