### PR TITLE
Update SecureDrop grsec kernels to 4.14.154

### DIFF
--- a/core/xenial/linux-image-4.14.154-grsec-securedrop_4.14.154-grsec-securedrop-1_amd64.deb
+++ b/core/xenial/linux-image-4.14.154-grsec-securedrop_4.14.154-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6008ff26911732ea19ed9d7f59585e1cf71dfa4753d81a260339898d99cdeb
+size 54096240

--- a/core/xenial/securedrop-grsec-4.14.154-amd64.deb
+++ b/core/xenial/securedrop-grsec-4.14.154-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:002972c20ea56597a373ce50bbaa8c9007db547fcf28f4440bea685369121c0b
+size 2294


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop/issues/4989

Config can be found in https://github.com/freedomofpress/ansible-role-grsecurity-build/pull/52