### PR TITLE
securedrop-client 0.0.10 packages for buster and stretch

### DIFF
--- a/workstation/buster/securedrop-client_0.0.10+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e868a013c992bf7eb9640c04a8f82f4e8feea30987bb6ca7c7daf8485854a862
+size 7281424

--- a/workstation/stretch/securedrop-client_0.0.10+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10+stretch_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05540934c589b41f8ae1c71a49cbfe74b04e0a12a1514c5c0b76ecd2a641e4f2
+size 7043922


### PR DESCRIPTION
Adds packages for securedrop-client on stretch and buster built using the logic in https://github.com/freedomofpress/securedrop-debian-packaging/pull/89

To build these I set up two AppVMs, one debian 9 and one debian 10 (if you don't have the debian 10 template yet then run `sudo qubes-dom0-update --enablerepo=qubes-templates-itl-testing qubes-template-debian-10` in dom0) and ran the client packaging logic as usual on the corresponding platform.

Build logs:
* Stretch: https://github.com/freedomofpress/build-logs/blob/master/workstation/securedrop-client-stretch-0.0.10-201911201150
* Buster: https://github.com/freedomofpress/build-logs/blob/master/workstation/securedrop-client-buster-0.0.10-201911201129