### PR TITLE
securedrop core 1.2.0-rc1 debian packages

### DIFF
--- a/core/xenial/securedrop-app-code_1.2.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.2.0~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b360d4e4fbd483a5ccdadcffaaaf50b03d366197d1ae037c8f302d55e0acf2c6
+size 12521550

--- a/core/xenial/securedrop-config-0.1.3+1.2.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.2.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15e4608787c7d0884099b4d7dc773f0475a597bf465f23d59abbb75f6bb6f7c9
+size 2742

--- a/core/xenial/securedrop-keyring-0.1.3+1.2.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.2.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8a45b3a87332b20775187c8059f675937505c1e16ed265bdc5a1b51c526ae34
+size 4740

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.2.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.2.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77fa9ce64dd7fdc83e159d70e4619e30c5e751bd86f843fa8996a7825fff984a
+size 3544

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.2.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.2.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faa44c51f9f2c6d033caf30ed2e1034ac917b6d2211177c6ec8592b91ebc1f1d
+size 6600


### PR DESCRIPTION
Debian packages for the first release candidate for https://github.com/freedomofpress/securedrop/issues/5004

Build logs are in: https://github.com/freedomofpress/build-logs/blob/master/core/20191120-securedrop-1.2.0-rc1.log (contains hashes of the packages, the commit is signed)