### PR TITLE
Adds Buster-compatible securedrop-workstation-svs-disp package

### DIFF
--- a/workstation/buster/securedrop-workstation-svs-disp_0.1.3+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-svs-disp_0.1.3+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6549b61d53f8fa29e5581484b9e6b8d172260e66e1a45140f8a5bf063e6f2429
+size 3268


### PR DESCRIPTION
Packaging logic merged in https://github.com/freedomofpress/securedrop-debian-packaging/pull/99