### PR TITLE
packages for 1.2.0-rc2

### DIFF
--- a/core/xenial/securedrop-app-code_1.2.0~rc2+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.2.0~rc2+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8bbbfb258225c9bdb4a69c558e4fa85a165b7c02b29c8870d18373134d3933c
+size 12523766

--- a/core/xenial/securedrop-config-0.1.3+1.2.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.2.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccc4ff75103991d77164103ab9ac3e35336f1e25a35109ccb6cd8b83c63f5161
+size 2740

--- a/core/xenial/securedrop-keyring-0.1.3+1.2.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.2.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:097fbb99ff65c2e12fd47ae50176ee232058d42a5aac0783e226dd3c21ccd03e
+size 4740

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.2.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.2.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e0cd238bfe4e3ba0333d47d2ec166e5328f42f9340139fed0f31a1cb7bf8333
+size 3546

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.2.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.2.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd8b0cbbb823b2ae17e2046e7e4eef4ba849737ab31f5bb041d3158209f6b3e6
+size 6594


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/blob/master/core/20191127-securedrop-1.2.0-rc2.log - the two test failures are due to a mac only build issue [#4191](https://github.com/freedomofpress/securedrop/issues/4191) and the usual builder image needing updates

