### PR TITLE
Adds reprepro repository config

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -1,0 +1,23 @@
+Origin: SecureDrop
+Codename: xenial
+Components: main
+Architectures: amd64
+ValidFor: 6m
+Description: SecureDrop server packages
+SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
+
+Origin: SecureDrop
+Codename: stretch
+Components: main
+Architectures: amd64
+ValidFor: 6m
+Description: SecureDrop Workstation packages (stretch)
+SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
+
+Origin: SecureDrop
+Codename: buster
+Components: main
+Architectures: amd64
+ValidFor: 6m
+Description: SecureDrop Workstation packages (buster)
+SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C


### PR DESCRIPTION


## Status

Ready for review 

## Description of changes
Adds apt repo configuration files for use with the `reprepro` CLI tool. Includes a distributions config file for all supported platforms:

* xenial
* stretch
* buster

Includes a "SignWith" fingerprint for SD repo test key. Using the test-only SecureDrop repo signing key, with full fingerprint 4ED79CC3362D7D12837046024A3BE4A92211B03C. Reprepro will retrieve that
key from the local keyring (on the apt server) and sign Release files with a detached sig.

Also adds a `Valid-Until` field on the generated Release file, via the `ValidFor` directive in the config presented here. 

## Checklist
- [ ] `curl -s https://apt-test.freedom.press/dists/xenial/Release | grep Valid` shows a date approximately six months in the future

