### PR TITLE
Add SecureDrop workstation 4.14.169 kernel

### DIFF
--- a/workstation/buster/linux-headers-4.14.169-grsec-workstation_4.14.169-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-headers-4.14.169-grsec-workstation_4.14.169-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89c2ee839c344d6b863adb5a0dd5351afdb080a0d2aaa9989821a2c5f75d87a5
+size 19442400

--- a/workstation/buster/linux-image-4.14.169-grsec-workstation_4.14.169-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-image-4.14.169-grsec-workstation_4.14.169-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46168529577d97ed137c7af22f29ab378cf5eca31a2d21818473adb9e187d9da
+size 58782612

--- a/workstation/buster/securedrop-workstation-grsec_4.14.169+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.169+buster_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa7a77166e9c74cd7ab3b85d3179bb71a4b2e319686563a6e8dd1fb8a6513909
+size 3028


### PR DESCRIPTION
As usual, includes both image and header packages for the kernel
sources. Also includes a version bump to the corresponding metapackage,
maintained in the packaging repo [0]

[0] https://github.com/freedomofpress/securedrop-debian-packaging/

The corresponding metapackage change can be found here: https://github.com/freedomofpress/securedrop-debian-packaging/pull/138

## Status

Ready for review 

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/1c011885c1ca17e214e6667c887a9cf4e9eef6e0

