### PR TITLE
Adds securedrop-workstation-config 0.1.2 package

### DIFF
--- a/workstation/buster/securedrop-client_0.0.10-dev-20191204-225057_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191204-225057_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f23a273a3f807dff0ec05a9a0735dfcb807e847649861bfb080271fc6a63f0a
-size 5726252

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191204-230551+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191204-230551+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf9dcaba6ac2a601ad66d7ea24d979114664dc95b1b551ec91fae1e81f631166
-size 5725256

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191206-061232+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191206-061232+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39ba657e652904612e7cf9ac959a98d7300657f8102ebd8027b2e51d7b4888e7
-size 5727004

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191207-061201+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191207-061201+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1aab9015b0140973148003378cb3d3ab44949550764b1542ef262c6bb7d1d0d0
-size 5726608

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191208-061043+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191208-061043+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08d8d59e02448dd948570d13532f3c187225a44ea9cee3de618f4762ff15a931
-size 5726772

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191209-061135+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191209-061135+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04321301e6359ce3702aca832ad87fbcb2b18fd0aa7274721ac82fd0cb8fa8a0
-size 5727292

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191210-061143+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191210-061143+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:64a1690b0929c6028bebc5e30e4778d114fcb81e38c19f830a57b002672e89e3
-size 5727652

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191211-061224+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191211-061224+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c333cd98eb8aca725db80cb6a12e7ae5542303f7031909b289f3f41788c3d74
-size 5727968

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191212-061224+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191212-061224+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:713d0c365c0392771b73bd33478f7dd46173cb595bf9978a4bed3f4fb94bf39b
-size 5727552

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191213-061228+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191213-061228+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8f645b4c9d61e87416e8776b0c1d48e095d6f6adc2805d273f73c85fbbef82f
-size 5728204

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191214-061200+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191214-061200+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbcec0b5d5e2a17b91088dac19aa0d3639946c08afed972b35873b77ab1c68e9
-size 5728016

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191215-061139+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191215-061139+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32af063092e678f215fd3a7dac030111de943762cb37959c47598c8edc8d0aeb
-size 5727532

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191216-061200+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191216-061200+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21f39b9acb0d179134cb9e60e582bfc16413cf69e60c0ea723b6e745dd86f2ba
-size 5727352

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191217-061305+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191217-061305+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3feb0751cf4fe2738944c833bb3a5a141d28691223438a3cb0815a8d27845865
-size 5727164

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191218-061249+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191218-061249+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fc40bac4792356f63507b6d4393eaf6d19b7f30ec5e0f76289f9277f7132f78
-size 5728944

--- a/workstation/buster/securedrop-client_0.0.10-dev-20191219-061320+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.10-dev-20191219-061320+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21b262f53454f24d1270f061baa2f5442eeb08a80181b26a3c0a328ac28d4076
-size 5727940

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191220-061250+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191220-061250+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db845430288b5fed32cd3f318edc32ecbbf6d4b132f23851eb80f05548ba6588
-size 5729176

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191221-061313+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191221-061313+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c02d703072d7a1f78b3500636044f35b4b3130e1f67b11bed4b95de6c7f13922
-size 5728404

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191222-061140+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191222-061140+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:610d4af3b5db3bfa0f3b8d499b052d1e8494eb6381284a9116b45af4a3428388
-size 5729588

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191223-061236+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191223-061236+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7c51940dbc853a67f15bb12f441845ddc6552fa61de9976327a1d9e0c2778be
-size 5729260

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191224-061302+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191224-061302+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82a9991587a0e693f281fd6b69986571a67e1ad2631522d1e31fe832f30c6d94
-size 5729760

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191225-061254+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191225-061254+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10283d211f746aef5bc27be7137360e3fecccb2b404a6e5c4c7d119078285347
-size 5729476

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191226-061306+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191226-061306+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2aeb4315b2da4bf69089f33d0bbde79f4f0446ac91e8d1f65227e3a126afa8b
-size 5729956

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191227-061247+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191227-061247+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f77b3b0f88255b62980453463726fbe613274d8dfdd0d498f4ebdbb8419d03d9
-size 5729028

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191228-061247+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191228-061247+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ffb9a29cd2a49109d896aa6308c7d53a03f4587169b685c993949a8bfc27186
-size 5728840

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191229-061256+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191229-061256+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:697b57eda8b356ff24770fe2692199484dce399066a08fd28bd652ec6399f900
-size 5728320

--- a/workstation/buster/securedrop-client_0.0.11-dev-20191230-061245+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.0.11-dev-20191230-061245+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e98dab1a93aef765c4eca8ca3feb9e2e06e6f320316b3c645bf8905ac130bfb
-size 5729136

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191204-225343_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191204-225343_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08e1818809ab4889bdae0671b596b82a6438edd0128a6957277d23a8aadc162d
-size 2832260

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191204-230949+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191204-230949+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b70c924294912bdae6979b265daa43765134fcccf7ebe29d0b3b3c476042123d
-size 2831884

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191206-061519+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191206-061519+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f324aab16e190b5dac2514aca48156f38e6804fb45b39dc89f893c5ba8f1ac89
-size 2832604

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191207-061446+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191207-061446+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd85759d6f08fa8732e4f4c138263b91eccc67c493b54890be363660d08ec958
-size 2832788

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191208-061314+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191208-061314+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d35d403babba403ec4bb17a7ec987bfa92a2877eae0cf89734440c2f3fbc2ff
-size 2832152

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191209-061428+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191209-061428+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60970c1791459491ea11c3f03da4c59bf9e6e28dbbb48d08db84ce29ad950ff5
-size 2831960

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191210-061448+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191210-061448+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03aedec2c8806541d409bf23406e1bfa51fd12a3a80ac21bcd52985217728fe8
-size 2832288

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191211-061521+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191211-061521+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd79ca6f86d051eb4ee0a5753785bfdd31fc5c6bb665bc2b13b454a1ed0fed9e
-size 2832348

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191212-061530+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191212-061530+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f37317e4a645fd403ebf135626b77083f6f0770fddd2c219f7d3f0a0d007abd
-size 2833044

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191213-061517+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191213-061517+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72eb6097169fe60e45e7498b7ff49f5cc1fd6022b29387ddb8a6a192013d7d35
-size 2832316

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191214-061555+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191214-061555+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8482bfd6fa7118ab9b4efa59f3f5434d1eb6546d37d7a15a0411a106fdb2b5e0
-size 2840080

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191215-061432+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191215-061432+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5e3421da50052506b2591c002c0dec50aa4edf072bf6355ad1392f1c5775f95
-size 2840260

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191216-061502+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191216-061502+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b129b09e7cf8388f669092e0408831a980a9d6e080b9eae2114102c8fc75f52
-size 2840028

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191217-061655+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191217-061655+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eed5dfb6ae1c3e90ebb8ebc9e116b233112e8bada8eccec177cbdb0bf5a09df3
-size 2840892

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191218-061544+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191218-061544+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dc0e26df3adf8be95acb789939de42609afd5dcf0d28e9e02f7321c959a31ad
-size 2840272

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191219-061612+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191219-061612+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c87415b51e644ddc6791b87819839244f47ea43f0f75546ba42b7c8613c2c796
-size 2840828

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191220-061546+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191220-061546+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff25f947c9bba2459d9784b8415a5697dabec7f03b35b2e31f5ab2b7dc540d90
-size 2841068

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191221-061647+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191221-061647+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c410255b7d5ab4fcab2e1912711d6ed9cd6391e5afa014b3b8b621929cc0fa1
-size 2840416

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191222-061430+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191222-061430+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9076c253077ca0dc9423ad89f02b2c28cab8ec5f953c87e89bded4d8a1b96335
-size 2841256

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191223-061543+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191223-061543+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8ec5feb020d0086564243939fe8de3b1090414dd9d0901911b72bc8556efab7
-size 2840412

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191224-061602+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191224-061602+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb32ca247bd3850641e164f257ad1eb47d0409aa0fce580200dbd903aa800418
-size 2840664

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191225-061610+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191225-061610+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2918e14abf277ccd0cc6b624cac6bad0fc753fe9f6abda938daf35c87976c6c9
-size 2840720

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191226-061643+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191226-061643+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1691d6d19b9dee7268163c6725190dec613d07bacafa0f453edef8c722610efb
-size 2841000

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191227-061544+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191227-061544+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5605cc100833dd885008c12e7ae051dcd34ed0c9493a2a3ad97bd2c5cb8b3cf8
-size 2840824

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191228-061541+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191228-061541+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0007322f749867c20c6e89adac7dcb40dd20e528e8ad21b89297b0b236192b8e
-size 2840904

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191229-061539+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191229-061539+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3af1281669802aba988983fc221c6c53c978839348b3bbcf4e9a3e3602a10ca
-size 2840844

--- a/workstation/buster/securedrop-export_0.1.2-dev-20191230-061538+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.1.2-dev-20191230-061538+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f612e46dde26917c4d017f4e2a81fe56cb2b6f8b492ecaefa4117eeaabc2ea37
-size 2840548

--- a/workstation/buster/securedrop-log_0.0.1-dev-20191210-231943+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.1-dev-20191210-231943+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:071fab3321746bba3d9d77d77c54fec0a9dbff620e7ec6b877825a5e5edc4839
-size 2816300

--- a/workstation/buster/securedrop-log_0.0.2-dev-20191213-005343+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.2-dev-20191213-005343+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2da9ba0896985586f1df16b646721a50abf286a608041a4bc6143b8f438a563c
-size 2816664

--- a/workstation/buster/securedrop-log_0.0.2-dev-20191213-061640+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.2-dev-20191213-061640+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4e5a6075ce8f09e9f58cc0496c00955328d16f62dbe479fd0917cd6293e35ad
-size 2816748

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191214-061704+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191214-061704+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42556eeda3255c45b2ad24db62b6bee28b2a6c6a19bd8a40a717ff79143027a8
-size 2816212

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191215-061553+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191215-061553+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:450c64b015eebf0968001e42a92c662b0c8f1747d221d26479ef9b40782f8c08
-size 2816412

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191216-061616+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191216-061616+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:170f78504fceeb2ab05ad9e5be38b042d79424c752bc8ce416ea6d0e7bdf090e
-size 2816428

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191217-061810+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191217-061810+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4afefa738c4d0b1e729ca37cdef937383bd41bb8d2827f88c303b3384a10c671
-size 2816560

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191218-061714+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191218-061714+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b7aa303afe10e6604cce8dbc8dc843dfd9666dad621d73c1052e84644741321
-size 2816392

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191219-061740+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191219-061740+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf32408085b86c26e4b39ffe15fe4b7b24ed4a9f6a20111d437dc8886bb491d4
-size 2816948

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191220-061712+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191220-061712+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8aadffa6fc5a2f38e1f1fcbd267ac96cbe166626699a65f2762e14e60c83255
-size 2817084

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191221-061806+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191221-061806+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c68b7962802a7beb552d9544744ad166b3108c27dea03184790c74d9fbafbb4
-size 2817308

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191222-061540+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191222-061540+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81e9ebc4195b402442eb6168c437adfe779cd8f07e2e57842f3789bbc08c7f02
-size 2817192

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191223-061701+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191223-061701+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff92484c668f23613864b12b865062ec1cd3f212738acfcdb5361f3fe6ecd18f
-size 2817036

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191224-061717+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191224-061717+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8bd5f595329d19da6a17338d9d8e5cde21ef40ded39f398dcb3fc24600492fb
-size 2816756

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191225-061726+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191225-061726+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bf970c390a6dda0fb958bb8c3cf1ad1691a535561217071b92627e2c954aed7
-size 2816728

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191226-061814+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191226-061814+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:873021093280b2f7d0003668a5a295ada8b2429f54dfa409e6b32d12d507ed18
-size 2815872

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191227-061657+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191227-061657+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6e6b1f42d84ba8a19ee86eaec2ac36c7402a1f35ed154af31de7e0f6b3eebde
-size 2817516

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191228-061706+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191228-061706+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cfb73b8a8a759a70f99fee2707d2dd477eaa39042cb6fa0c2062d709aaa33f3
-size 2816904

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191229-061651+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191229-061651+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6be44d5a40c631e735154e149f8076f1288e2433dd4bebd49d0bc69734367be9
-size 2816956

--- a/workstation/buster/securedrop-log_0.0.3-dev-20191230-061713+buster_all.deb
+++ b/workstation/buster/securedrop-log_0.0.3-dev-20191230-061713+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b90c7045ddf796bb858ac5883f2e23989f4460ad0ecbb1696938e4c7be9d4753
-size 2816540

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191204-225226_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191204-225226_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a64e1557d5b57211abc214891c4d7238d1e21fdc4a390096087eb9abae1ff59e
-size 3143532

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191204-230822+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191204-230822+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f9e9059897d941506cd63ccecd2558cabe834e198d7afb9d8b516a9d39c23cf
-size 3143012

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191206-061406+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191206-061406+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5588770a7a4b25adc188027f0cf8e9c513ed49d0bd57e047cb8319a762140dea
-size 3143080

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191207-061328+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191207-061328+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c38d329f833c8e5b0b56ededa4ee9c7eb7fc37ed35e57392e00d15800dcaa895
-size 3143768

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191208-061203+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191208-061203+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1bbc47d05cb3ef3805a3528ef39a73e6343ac4a2c1725220c54c8a1bfae03e9
-size 3142260

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191209-061307+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191209-061307+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebcbb0de665c3f14c0096add85260908374694ff00015537fb20c69aedc627d7
-size 3143340

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191210-061316+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191210-061316+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59875a137eddefb96602bdffc72cb57f7a189a2f24622e6e07cb458f5ac2a4ae
-size 3142272

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191211-061351+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191211-061351+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:042a7ddfd36c6dcceb9f406b6de050f81abecf2085850702e9dc40d389e74440
-size 3143036

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191212-061354+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191212-061354+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81752fe3b1e6334f82865e0404d961ddcbe7354da843138a9e3b1c9a03d6a269
-size 3142968

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191213-061353+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191213-061353+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eedd72e364a8551dad84e0be642e30d2f9b288189cd005e44c953b412e505ad9
-size 3143144

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191214-061400+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191214-061400+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb40c8e5aa2f60bb64560caa247e80a2fd4436897baaaf995c6a22888926606e
-size 3143364

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191215-061310+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191215-061310+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2f6805fcd77c0bcce8a3c599709dd971247c72b375a3eb4aad26ac30311b9e4
-size 3143376

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191216-061336+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191216-061336+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eadc3fa7f8a663dcd85bdbbaf68af695fa63ea0ca8f8ea6fafde536acc091e12
-size 3142560

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191217-061514+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191217-061514+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b08f026a8283f4a78aae88e1aa49ae43bbf4eead4fd72f4c84daf82c0da1270
-size 3143244

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191218-061430+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191218-061430+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0a3f6dbc462d93c4f3415b44ea0672aa5a9e17eda4b7dc5b5f596a9dc2c3678
-size 3143276

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191219-061449+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191219-061449+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:929b27ac36e6222b2344fc13f1e0429c07096e62456500ecf6dcc42ef84cb62e
-size 3142784

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191220-061418+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191220-061418+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d1a3ba927062675406149884af999cafb6cc6c4e4428d9cb75b086292a33b58
-size 3142748

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191221-061432+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191221-061432+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94e171f7923ddc8213353b3accd4177fbc48bc814118049f71462ddcbb825df6
-size 3142304

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191222-061307+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191222-061307+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:530680951f74dbf219ecf1dfc9fe012715a54f014da6d22b21de72222b8e43ce
-size 3142972

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191223-061408+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191223-061408+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a711bc77517d667ae32a19d72041f54a0217e97fb895c5ec355b61d62cf92af0
-size 3144028

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191224-061431+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191224-061431+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1227fd1ec154285467907bec9e8fa4b7aaf2b716c6376fc82caea3aed086b2c6
-size 3143244

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191225-061434+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191225-061434+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc7416ca16a0f74cb8e073169a36fa184b09eabe4b98ac885fd17bac197c651c
-size 3143476

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191226-061507+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191226-061507+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81821b5912dfe0cb631960cd6583e373ebc41235ba472699550ecb8706a06a75
-size 3142696

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191227-061421+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191227-061421+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b06d24164013ccea040f6c32ee3666dd3f8e3e68b7889f0470490e92631ea1b5
-size 3142484

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191228-061416+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191228-061416+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:caaca96e13d8a81f2c212143a9522ce1a2f36e9305beff326f8e2dbf725c09b5
-size 3143484

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191229-061429+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191229-061429+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d77a7cb66ea85ed4e7e483f641e7e63d89956d60925f0cfb2bd636b7e6eaa76
-size 3143152

--- a/workstation/buster/securedrop-proxy_0.1.5-dev-20191230-061415+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.1.5-dev-20191230-061415+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4bd7e3fdbdd35e640296ca160b27614b78f1854b3312db5aa332f9471282587
-size 3143016

--- a/workstation/buster/securedrop-workstation-config_0.1.2+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.2+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cdccf865d37f107d357ab7669a69b98a32bdb2756fe58b12854258525cb0f11
+size 1572

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191121-060620_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191121-060620_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a85305c82ad043fe7aba61dc02219f127ab6eb4164565a8e0ec4008619bdc243
-size 5673118

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191204-224554_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191204-224554_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7201f4c2f57dbd541f8471e6e91555f98e9b2deb4bd70280ebf4c93d388bb40d
-size 5672738

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191204-230118+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191204-230118+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5345c47e586f543446de6009493b4e219c77691a1e32a3419a2ca103dc34914
-size 5673782

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191206-060659+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191206-060659+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b179414d104d2c4aa7dcde02ed22f8f18fd245eaa1178f577e608274d224589f
-size 5673710

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191207-060713+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191207-060713+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd62968ae12fd244ac5678ab2316dc2d7073be6a72a8c16e2f2a640da1466a8d
-size 5674152

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191208-060558+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191208-060558+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3c7984b35944e640a413992ef5bfa0f6fad13633582233853359006c9499e70
-size 5673956

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191209-060617+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191209-060617+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53b50a1c7022c344b4a11712749287ed75c71852ae0989f939de8efe0583f690
-size 5673206

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191210-060634+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191210-060634+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24c9c14a89efe1027ee59185021436cd4a1d98d10ce7b3d1098401a63d5d933d
-size 5674664

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191211-060704+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191211-060704+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ecfa2ea32ab694bed3529c77e43eed7d4b6601f022b5d21ef2cc61410b396e4
-size 5675230

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191212-060655+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191212-060655+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1b0aa2881576717a5016f925aec9e1c59e9e14934efc1a77f340ffc21fd386d
-size 5674332

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191213-060653+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191213-060653+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce95fc8f0665555184393cd72f2febc1dd02611c834322e3f8f94c0f22091e4f
-size 5674150

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191214-060641+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191214-060641+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7244621b28e0c7734dc04217c5a2eb4a83f095b809ab798be28d1cebec00b0ae
-size 5673684

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191215-060628+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191215-060628+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99208b65bfea7277bb736fad1a0bb23659e369c403db6d790079dbc6c0a9d2da
-size 5674670

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191216-060643+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191216-060643+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1731dc6216b04adc3da71085ae6cd65851ad46aa8286f13417bc7e77ff14ec6d
-size 5674930

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191217-060647+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191217-060647+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aeff620376ef6cefdbeae63462af9b0b82ca531977d1fc0214301a9a300ab2c7
-size 5675076

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191218-060718+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191218-060718+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3feba925578bc0d0686844a738fe2fd664764183ceed4e771325f23916af874
-size 5674136

--- a/workstation/stretch/securedrop-client_0.0.10-dev-20191219-060654+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.10-dev-20191219-060654+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70773a6aa31aebefc27052768123493c603dd7e6ef6864d5aab1cd0d5197aae3
-size 5674960

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191220-060644+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191220-060644+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59748a7480979845da4f33aba3b3e1287d1ead23359a38bb26a2f828aba2d0fe
-size 5675944

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191221-060742+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191221-060742+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74d386be0b7f45bc809f49474b297e5c57700235ce514035a23332c9c27579dd
-size 5676538

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191222-060608+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191222-060608+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c8c1e101e5d92c39527109c93e47f57ad365978cc330b6565d8ac1dd56f0082
-size 5675450

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191223-060646+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191223-060646+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1166adab7ab15a94a5e6cd23ed1e2d2198e2dec7f0e9a7d3e04dcf7a5add9295
-size 5675362

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191224-060659+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191224-060659+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b314fa06f316853a52b05b04307a83aa972b619f0ce0961808549e0db15ea52e
-size 5676064

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191225-060658+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191225-060658+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c46468e0afa18bfa95caabf328644c6aedd980b6801f68485418c421a5e67e5
-size 5675792

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191226-060651+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191226-060651+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c48a6adda92760e870a98fb45f5558ee7f3094b0e6edb1b9fac68e4fa5154c8f
-size 5675450

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191227-060643+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191227-060643+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a834ec1d4da67475dc2dd5dc9d08fc04de2b1b31158d4228a64b80aba00f39c9
-size 5677136

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191228-060706+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191228-060706+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58d6b35be43f9359c6a57c00ea5b846385ca320ef504c5500ce8741c56896f9a
-size 5677032

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191229-060656+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191229-060656+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5c9af8432c6a0f655cc47acf4c8972eaba02f462b8583133d058b1c04b9065d
-size 5674626

--- a/workstation/stretch/securedrop-client_0.0.11-dev-20191230-060643+stretch_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.11-dev-20191230-060643+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b178dd668aeb2e7ca56d880e29ea15d6d887f903fa46bd35d64186dbc95bb2e4
-size 5676044

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191001-060558_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191001-060558_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:475882fca6e21c8f7c1e4c77c8e33d1cf20317e6e47e8819864fd28ef81a56fd
-size 5658090

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191002-060545_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191002-060545_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cc3121c5455a283ca2e07fe31ed4f29a64966bf389fca6b9d295b4e319d703a
-size 5658672

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191003-060608_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191003-060608_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f2e22845999fcb94ed307c474ecac7a00b07233db101131e33d51b4dcc38e3d
-size 5658818

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191004-060611_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191004-060611_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a29137570c183cebdc243cfa5d544a037e2ccabb9650cddadf58310ffbbfe6d7
-size 5658160

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191005-060602_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191005-060602_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cfea302d4712862e1405f6e35183020217fd7e7d0693d533e4fb77756eca6165
-size 5658642

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191006-060535_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191006-060535_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c0c03ee8f62cb384ec4073024f7cea815cab707c765740628bf65d3f65fdea6
-size 5659206

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191007-060605_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191007-060605_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52269646ced99eed143e7d5c43b62f3dfb460b00edc0c700c9c8f44808ca08c7
-size 5662046

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191008-060602_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191008-060602_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb426b865c0d28ec1c3b036561632e0f1e9f519003a6f3f5c4a8e23cf0733cc8
-size 5661508

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191009-060602_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191009-060602_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c12c05f9b23be20d5163aefd7f248785536493b4ee5140e621da6dcd238eddfb
-size 5661336

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191010-060517_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191010-060517_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cdd9edbb40eb9387e1cf262e2759de3dfad1d207615a398be789e43f64228ad
-size 5661346

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191011-060513_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191011-060513_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbc34309f813d172ba697222b77215010f0a267cc4abf580c8fe6562da601714
-size 5661582

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191012-060501_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191012-060501_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e70c0045dbf0c77dee449f7881bcca376cf7d829d163f71e0afcb06ad021afd
-size 5660554

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191013-060503_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191013-060503_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:801590b2297d9ac0d54d265ae63c83b7c0fe37f73aae1c151995fa7068c67501
-size 5662004

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191014-060620_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191014-060620_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b04d47596038c78056ee13304b97cddda2b4f61822e54cfd907c7b8a3d297584
-size 5661866

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191015-060512_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191015-060512_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b514d4c730ae524b384198cb83495d100aecf6aaf28498614066406ed23a5246
-size 5663810

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191016-060534_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191016-060534_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2e386162522540f56528e261ec5bf93794525045d648a00967b787f8455dbcd
-size 5664106

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191017-060537_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191017-060537_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d74f1168b8e76ccd0250746f46f1866a21524f844baa6b34cc4cebf9bab01df
-size 5664042

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191018-060640_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191018-060640_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5f7f6cefba00892c2b5f8c247cebfa0ee5c755a7dff9d5f93523d7bf4c9239a6
-size 5664946

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191019-060531_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191019-060531_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0e97b5eaf55656bc889e84f522007d66d13edd8b9dc9be88c40c93c1f0c1d0c
-size 5664842

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191020-060528_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191020-060528_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a25b93df0263c0aa6187641b62d66969b37d0eaee18f19618b1bf48f0702db6
-size 5664890

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191021-060544_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191021-060544_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0ee44c20c2136d58af8a2b430dddf9cc8ffe5878028bd28447c82f8203697da
-size 5665286

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191022-060539_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191022-060539_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cdfe4427101b40265e9ed11cb209be528271fa96f578c5cdcda36aea3b66a2d4
-size 5665008

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191023-060646_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191023-060646_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2025821b0db85f07967c71432db94c2a9f26e2c9a3d19fafc96554a003562a4e
-size 5665216

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191024-060544_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191024-060544_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2ffa5fefc2938cc4bd799c60a66181c47b8e542cbc4b9f1d3e91299c753e72c
-size 5664562

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191025-060544_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191025-060544_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6564979275821fce3ac818c418227ec38d750f7c76a3ee770330ec99632d4a25
-size 5667070

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191026-060554_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191026-060554_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d89ff0e57760551a3474fde656cae50f29a0ec8e44f674353c1caff3736d24bd
-size 5665964

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191027-060556_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191027-060556_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2b3f415ecaf0aa476a889b3951a173119de456b1cee3fc59e87d149fc444f48
-size 5666056

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191028-060555_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191028-060555_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f53675cace5576d97e207ded797f08c9c15180833fb935194f1ffea175f0e922
-size 5669908

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191029-060602_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191029-060602_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b3983851bf9994e886969373766da73202a078c610ded56d7fdd24c0646d576
-size 5667790

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191030-060623_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191030-060623_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a8a3b2c259f7d0e41921c774b0274895adb68cf5c01a4132c6794dbccc009bf
-size 5668046

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191031-060555_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191031-060555_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50835b837ab614f78c23f20d0612368431b2d33dfa57e2f4948913fda5344332
-size 5668706

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191101-060543_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191101-060543_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ede7115e66383481fc56591508f06f53a58229e35d52603ccb3318aed2f6c00
-size 5667762

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191102-060532_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191102-060532_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26c4c32929ac681ff04b4cc49509e3241f83fb19dc093abe321a1e309ce029ce
-size 5667772

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191103-060530_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191103-060530_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36b1759ceb665ec05fc8aea3c3358972a5519a7705a8381217013026b872bb31
-size 5668124

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191104-060558_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191104-060558_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e811a15b96ca888398407c07d26d92460e1aab368ec42b8191e465c66e537f7
-size 5667238

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191105-060621_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191105-060621_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7caafad8a69a986c88d698c501fca349dcd6ae868e97ddbc2449214fedeb8c7
-size 5668686

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191106-060602_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191106-060602_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:163a2016b1117ad726d4e69dd4251f19f2e04a3270b29750de1c63fa34083941
-size 5669534

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191107-060604_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191107-060604_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b42a69002b9835ac5d0ce32aa5c65f1e6f5032f6f019e3921206e3828fd78c4e
-size 5668524

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191108-060640_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191108-060640_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0336bde7f39f3a161abd4b2bb93cf7d638057cd337a1c923c1d8ee7417069506
-size 5671306

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191109-060546_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191109-060546_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5d4d5169841002a0c0e51505bb25fccf8d2c864b01e4026b806392f07ce3cc4
-size 5670372

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191110-060545_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191110-060545_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa37b4fa72ba4db84e049e366d9c138d3e473e472441d84823a63a31c2acf54d
-size 5671512

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191111-060552_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191111-060552_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f01969643f3f56da3440e7dbee00521178a9b7b9ac8e51201a30be719e9e138
-size 5670210

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191112-060641_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191112-060641_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8d0ea9b51f72f87a45dd9fe639019f5d2e4fef07ed7d0c4b7cb4b3dd905d242
-size 5670674

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191113-060640_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191113-060640_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:683933c20397d478a731ef9a1be7c42db74e14bede40e001c3628f77e5cc0d9a
-size 5670056

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191114-060631_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191114-060631_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e13ca3d607ad150cbae2980b5450b0dca5a6e54976bfba360eb5ef092a04e921
-size 5671470

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191114-160008_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191114-160008_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1644b6a0f5e2398a4f0224bc5b51953cf7e5421d988b5b6a8981e8ac09c41d14
-size 5670904

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191115-060621_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191115-060621_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f198c3d60b750453bd742918a94351c18fa94c0814321d44fafa88b0a690de5
-size 5670516

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191116-060552_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191116-060552_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c82797b9eaa6414712c7cbc78e2c901324a18ca1c174dd54db61cfe35336664
-size 5670402

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191117-060626_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191117-060626_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41c56559452d8b100377780bb781032f2a3096ef478e97ad703333e5971cb05c
-size 5670916

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191118-060545_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191118-060545_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1879845c3a87e8101f2616a91ba71b310d6e84c9d3a8d62fadbd72e5eb544bfc
-size 5670268

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191119-060707_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191119-060707_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02700c95c2705c84d1d70d675e84185c9d848c260639ad1543fe1a6091f09f2c
-size 5670890

--- a/workstation/stretch/securedrop-client_0.0.9-dev-20191120-060617_all.deb
+++ b/workstation/stretch/securedrop-client_0.0.9-dev-20191120-060617_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:962847d380b0d21241c0ea3e8301506e64328c9a38c5c3e208ddf71832617f4d
-size 5670960

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191001-060756_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191001-060756_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bd91467868bd006bdee98abc13c19f18ab494e6d388029160b705154e262475
-size 2771676

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191002-060753_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191002-060753_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1475ef9880fcd363bc982943a61c5c17eefd88dca42947e3b5fb996df56758c3
-size 2771948

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191003-060845_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191003-060845_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fac5e625eacc9784eba8de441ab67a6ea0b7e0937915cf3189e9d26246683d3
-size 2771596

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191004-060823_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191004-060823_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0536691ec2692fb4a463e4c7a3a80b8cc009167a85bc389f54bee22c9839bbac
-size 2771244

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191005-060807_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191005-060807_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60709ee58d8885ba0ed3558f53f60239712faf71c58c2f9c1b0c448334c559ad
-size 2771596

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191006-060726_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191006-060726_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0724c87b86c375a2fb3681741d1d7f86299c23cd36c9f3b749d448c6309b69cc
-size 2772262

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191007-060827_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191007-060827_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e48b4f49d9d3bf9e9685ef85ae3a289e174a197e5cbee6e475dc8c047eb86fa
-size 2774604

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191008-060828_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191008-060828_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3922c69795c453adb822eb241711e4c644b34fbfe372f23d5f30d8ea7a2d3c12
-size 2774460

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191009-060815_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191009-060815_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0370a8be2839b3e33f2c183f73fc32fa7d67edead3f4864fc1fa546356c0c255
-size 2773580

--- a/workstation/stretch/securedrop-export_0.1.1-dev-20191010-060702_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.1-dev-20191010-060702_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ad3cd6fdb6ce7b5b333ebc82d790712812aa396444cc4223994ed09b7df8438
-size 2773960

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191011-060715_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191011-060715_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e229b5b8a89f2c49cdb9f1e5a8e3be0d93def3e4901037a72af9140d547ddae3
-size 2774702

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191012-060715_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191012-060715_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e1873bf4b68ba4ebbd6bfd62c7a2a8ae8738e8ae9953d7808a557cc01ad1c84
-size 2775668

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191013-060638_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191013-060638_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c0022799725d02fa883c9ad4b4cf28ba376435fc64d9997180d11af0cb91ba3
-size 2776022

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191014-060807_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191014-060807_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a1d3a585f16cf0f6bad0489a48066394920c9318148eddb59101d756ebb00be
-size 2775134

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191015-060658_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191015-060658_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85a20ad003511011f79b16164d309824233b1c7ca612f0aa204f374c48f69ae2
-size 2778046

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191016-060717_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191016-060717_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5dd2a080eeb185cdb0f73c04dfbead473e88cea8457c5691380b592388d3a8f
-size 2775948

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191017-060727_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191017-060727_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c7bbebc4a467fc1c938955bebb560fb382f69d76b9eb5ca299c9396ff0cbde5
-size 2776682

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191018-060822_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191018-060822_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91a552c7e35943e01bb1e00b2e2acb5ff38712ccdaa4ce4827e231d3964c38e0
-size 2776822

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191019-060708_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191019-060708_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bc64e49f63725af3f983841c3687bd36d30b62c0527440e209b78f7337b5df4
-size 2776484

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191020-060717_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191020-060717_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7687aadc20c3c18fe630f8219c3e461a8a9108ed53004ea7f87c7edc99460e16
-size 2776658

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191021-060735_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191021-060735_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc4f1ccdb72cdb590b8499a9a246ad61a116f9f1aff353e22920bc6adac44641
-size 2775994

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191022-060729_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191022-060729_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3aa5db945f726a6cb4ac1d8c49ad10918f2a5987a81b788f32ca8f95d52ed62
-size 2776160

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191023-060847_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191023-060847_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1eaaaabb0bd4913b416d4dc91cf98b5d001a0d57e9095862375c6ba623e89f81
-size 2776286

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191024-060738_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191024-060738_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15d1915d5fa23c883eeb5e4f0c48caef649f934dae7c0cf1458708bca52e7d25
-size 2776994

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191025-060754_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191025-060754_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30fb90a0c025fbec66b66db01bea2c173b0d81dd6b7296913eaf5208b4eaaacd
-size 2776902

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191026-060759_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191026-060759_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1774c69abc883639a14d8b3730db7cb519b362288ba542572f9c4cbecb085c87
-size 2775688

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191027-060755_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191027-060755_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3d120809f100e0e094dc784e942bc85f15381f30e7437f558918687c6ed85d7
-size 2775872

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191028-060751_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191028-060751_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:731633a6478ad002528c920607a7aa493a5cb6f359d41da9c5efca835d41a3fc
-size 2777638

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191029-060757_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191029-060757_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:547a05013242a0cb1b5125bd380109c4e02fee2846e6aaf6cfd34062559f1059
-size 2776852

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191030-060834_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191030-060834_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4745ec7bdb0d9dab427dbf610d003ef30f5604e6004d030c9107c079661f8c94
-size 2778140

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191031-060746_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191031-060746_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:902e85bf0c82137210742e3bb5445e0482279dc49595c713cd92344b473c6847
-size 2778558

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191101-060742_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191101-060742_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd52c4de2869144fe649564f8ac76fa278d8da9a42c10e4549b9eab2798c2633
-size 2778902

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191102-060744_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191102-060744_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16623465267c662d1d117de49b74436325f91c8b67175b2182da9607f5e6dfb8
-size 2777830

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191103-060742_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191103-060742_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b610004c5482a53bad614cfee2d8a8448513b1d7fd6174607839b9c0c999ff9c
-size 2777632

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191104-060758_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191104-060758_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb0d2995726ab5e3422ddd2b9b42852c9dad116fd47d9ec78595d39b19cb45d8
-size 2778076

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191105-060835_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191105-060835_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9f8f7a9fe52051e3fd8f39b8084ba15bfa19d9719a482fd04a6defca87d8272
-size 2777630

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191106-060808_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191106-060808_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d5207099d43f7751ab89e27fcf1c3b01d181351d76829dd48c35c6de2d6e9cd
-size 2778208

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191107-060815_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191107-060815_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:490cfa824ab402217c571d6a930b3ca7196e6a1341671a5c3e024d5c3e938540
-size 2778168

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191108-060908_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191108-060908_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd2f27f56933807c5346e04464f52d3142a3d9b8a9951533e9258a9e2a7ea863
-size 2778928

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191109-060748_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191109-060748_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c0a1355699d9d1d5980d0341ac416964fbf8cf1e1a0513ab0e06d8148a2d1c7
-size 2778948

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191110-060759_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191110-060759_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a8b43cc3576951a8816499a6220064492837aca3272da3730c250b89f552454
-size 2778568

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191111-060803_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191111-060803_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:243f78cce169c166f25307c4cf37677614e73ccd476210a3a5b2a88f64c615c7
-size 2778394

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191112-060857_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191112-060857_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e6a0d0f8a9fb3a40dd7d89903975aea2ce1658a911c509e94276f664037d469
-size 2780142

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191113-060925_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191113-060925_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ffcf99f8ffce8b37817ad52244f9ec17d5ee01601f008fe11e2a929ba5fa393
-size 2779286

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191114-060924_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191114-060924_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a8b91e4fc436caaa22c0f191da2187e36765100a3eb7c3b87a17b565c5f1c66
-size 2778930

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191115-060849_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191115-060849_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c6378f027a180eb565e7ac05e5820da85a80fae9f8f5c1da9618f66f62b08de
-size 2778330

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191116-060808_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191116-060808_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecd316e84d7dc17fe9f0c5ba2c22b2822afff6a6155b866b49a4172d70df944b
-size 2779368

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191117-060850_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191117-060850_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cf3a49d9d096ab5e20f80e0bc0f00594a9be75cc1e51df9de1ff19d642da1df
-size 2779334

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191118-060807_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191118-060807_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5294f509182b22133e6f398774136a5a3784cc38cfc91f71b9cbe67a33d0bdc
-size 2778680

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191119-060929_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191119-060929_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a50027401ca3934cf84efb95f52ac99d135949026d58e242550db53bf4d00269
-size 2779422

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191120-060926_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191120-060926_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d84b7c2597b9051e190ab0cf1e0325a349a57e6e04ed9049599e4307f95727dd
-size 2778146

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191121-060852_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191121-060852_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae360a0e481df9f294f660670e522c8e0cd8b8a464d6efaa675d7cbb601ec16e
-size 2778956

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191204-224835_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191204-224835_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34a1d505837669e19b11c525256a4805f073e70ebd660e6da88f9a72b797068a
-size 2778702

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191204-230349+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191204-230349+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d30f2dddb1e95a0622813235a2d8a812427df52119c9293555e99d10c6ec95a
-size 2779208

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191206-060946+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191206-060946+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab39c48e398481e89bc609122e608d449d5da30f4a6f119addbf5ec3643e3430
-size 2781718

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191207-060951+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191207-060951+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12f3b9be03a8b63a693328e488b4a72b6c2776f3a53d51cb1ba4a7eaa829e1b5
-size 2779452

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191208-060820+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191208-060820+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:973bbbfcd3dac622a5f316d94203c156420a405a8efa1627a5d901c47fad918b
-size 2780156

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191209-060910+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191209-060910+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6bd0778e1866f38fa50feaeb879fd716152ca83f36d737da93f42a232886aa4
-size 2778982

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191210-060910+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191210-060910+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8b4ea14585889fa04859ed244c8b539a96906e12abb56b862d12f21fc489b18
-size 2779498

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191211-060948+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191211-060948+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c8ea49a5bb380b8274ddcd047127c660a87284cb9e48d3b608fd3f1f1b18dfc
-size 2781152

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191212-060951+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191212-060951+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f37b3a914773643c101fba38de6d3a8275c7c678401d9e8b96b8a256d84873d8
-size 2779498

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191213-060951+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191213-060951+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cc5b8cb39ca8d834965652ba4e87e1b9543e9f0ae8bfc418ae738ecb14ca4fc
-size 2779336

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191214-060932+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191214-060932+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:570e53ae6367367ccf41edc4875bda35cdfef659a207753a4d30336d663df04a
-size 2787430

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191215-060913+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191215-060913+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e12d72fd3a1a2af4c2de589bbc98da5d3a9ffe80c54aeb740f670592d68e1c1
-size 2787794

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191216-060926+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191216-060926+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29a09e2ef271aadcf22a88ac0daaa04c12e33d019e5378ee65a0d7155b3f0a2e
-size 2787318

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191217-060930+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191217-060930+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3193ed8ff95dd545fff4997290de4e8dc738eb6229a9ca3a9df9f13621a821
-size 2788156

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191218-061016+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191218-061016+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bb7c6b99b74dc247040df490c5757825e9fe282805b48ed8a2e512d0fd07014
-size 2788142

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191219-061022+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191219-061022+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28960463408d5902cd8f6cd8fdcf6b9c955c21ca7554159a98001b974d4ee58c
-size 2788224

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191220-061013+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191220-061013+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e441597bb6bf65885208230b2f01b22b956fb0f01293be029217e7807c7489c
-size 2789544

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191221-061042+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191221-061042+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7e504cc533d1198f709aa1778f453bc247dd6ed77d85c9fd025f57ff6fcf726
-size 2787722

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191222-060850+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191222-060850+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:179683332f4bf2f362045b9270b5b67beba995668cdcf3ccf1637495cbd4d897
-size 2788266

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191223-060949+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191223-060949+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a75030ca4546b20bfdfe72273443c0e96660d436d09c62696268e5959b98c5fc
-size 2787700

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191224-061007+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191224-061007+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:474adea528e06fc30ed26a3cdea35fc303b297968592004b064094e2eae43c95
-size 2788816

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191225-061007+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191225-061007+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4215cfc640a557b7afa6f62796fffa43ac3556dab722b588451bac6eb21ae90b
-size 2787204

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191226-061006+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191226-061006+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:057add763888056b47d0a5a8f0035b415e5b56be57ec717aa165c0b125108929
-size 2788976

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191227-060945+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191227-060945+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88e0e7e54dad3cd882d5d9e49b89465a9289f8e8dcedc141f5d7cf32687053ef
-size 2788222

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191228-061011+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191228-061011+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ccccc011c10e93fd118241a0ac661ec041d77d395f1b47fece388e83fb2152f
-size 2788424

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191229-060958+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191229-060958+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:807bdb2d1514f3bee45461a034047fce69eff767e13ca5f8565983a803e17fc9
-size 2788056

--- a/workstation/stretch/securedrop-export_0.1.2-dev-20191230-060953+stretch_all.deb
+++ b/workstation/stretch/securedrop-export_0.1.2-dev-20191230-060953+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a51b42bfc6aa32ea3b0d5e339878a64a420e70240a94ec2dfc236d5bc086bfb
-size 2789238

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191001-060353_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191001-060353_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df72f6d630112578498feb465d712a787d8019acd3e67d636116cee7c93cfe24
-size 3076064

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191002-060340_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191002-060340_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abb2b1b35d2ce51af7c2e1d78a9c178fd65d75bd09986ca0b0e917a52f7848b1
-size 3077218

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191003-060345_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191003-060345_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:746aff18c3d2ddaadc36a61c3d7b7327273c99a914f7e165542b28285137d0b5
-size 3076722

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191004-060354_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191004-060354_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b4ff02f16f3a6e41a7a310a3b0b9c56ed18a9f3a2e2adc33ab1ac4dfa9dde91
-size 3077060

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191005-060347_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191005-060347_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7cbe8ec72047cd25541cf8dcf9a2b95f0292347b7bad0a15210c20281472fadf
-size 3076600

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191006-060340_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191006-060340_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3715e6567663727ed54b8a6954ed7ed9d139ecdbd8ad7c16b377d64a9e48766e
-size 3076322

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191007-060348_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191007-060348_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3baf1a874a802c21a85435a583a1de3b7db1411e7c4ef6e99ca4b910df1aa01a
-size 3080066

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191008-060341_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191008-060341_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df5f2e6832204f00836579275d1183a30b4491efa24cafb4361b6facbd5593ed
-size 3079668

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191009-060346_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191009-060346_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84660422ae66af1eddadebfa2ebcd31134ce3a8f61764dad9a86d2d22f96ecf6
-size 3079508

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191010-060339_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191010-060339_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bf173deb3d82898d9d18905c95b04c700206950522cf5a18f92aaa6b910ed9c
-size 3079184

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191011-060342_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191011-060342_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:581a6bf34b729a80f4caf9a5bac1ce020e23fa22bb80df81a17e32eb80bb103d
-size 3078860

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191012-060340_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191012-060340_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dd12e4179b2d47ef0408657707a45173ba7b013c9c96b1c1680a85082c226f9
-size 3079142

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191013-060334_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191013-060334_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5499d718a9fbf521d8e2fb7be4ceb6d3c10072060141a2fbbfd451884c4952bb
-size 3079506

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191014-060348_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191014-060348_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8eacbad1658351511355e5a16597a848ac995ad65129329f4d3f757f3756bbdb
-size 3078932

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191015-060341_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191015-060341_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f07d31d2cf7b0d97e2b02b9a8fa6be817494558f5c3cdded43f87b1089d1591a
-size 3088710

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191016-060354_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191016-060354_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb4daf74060f7eafeaf9c82590ba7bd77ea547089a743f3f963f1444908a3ad4
-size 3088688

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191017-060347_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191017-060347_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0d99896734769b3dc94e5b99c928af9f9c43c925826d5db78dc9024c3a0bdff
-size 3089218

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191018-060403_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191018-060403_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b65d3b6cc56f7528a778b0704856eb564f715dfc593854e72d19340587d39f4
-size 3088740

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191019-060356_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191019-060356_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd2b477b02e45fefb5f7c48cc73db5aaf7b74731bc68f390cfcae40f9c5a62b1
-size 3088848

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191020-060347_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191020-060347_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34f46a23603df05eca4320fdec8e060d9756821ee27e0e71e0f9edfe63062f15
-size 3089356

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191021-060354_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191021-060354_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2d20104bd5e7dc1fed27fae553de02d981fa33d603368d1b4a971d84dabf47b
-size 3089208

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191022-060349_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191022-060349_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f9bfb8977ec8ce7207a8f82d898ed548212cbb2fcfac6ec7319fe0f36fd07bd
-size 3089082

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191023-060448_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191023-060448_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b630f0cbfe2d635ca2aa47c69d08fa520d2bcfa3d75fd4e4f60e8f5aadc648c4
-size 3088802

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191024-060354_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191024-060354_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42d7678524bf822e55beacf6dccaa9cda2860b518a31faa0c1eb6595f8b30cc2
-size 3089452

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191025-060352_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191025-060352_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73a4c73b501c95eeeb605665c3672b36d1fe285db7f6e813bca049c45aa116b3
-size 3090512

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191026-060401_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191026-060401_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbccf3ccdd9aa83526b2257ab52e6671a764a33fbd86016603fc2b843d5e4598
-size 3089012

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191027-060349_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191027-060349_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c6078bc21656b796069694ba69c05c7e3d0ec238f2361ad1f093bf091a23d4a
-size 3088246

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191028-060402_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191028-060402_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97dbe5d4b1fab8f953c25c6722f06bcfef838c8e8c8cefdc6bdfdebd6d3c4bcf
-size 3089446

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191029-060344_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191029-060344_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a96b97ac9f824c2f330ee3ef1f949761be5e94d9463d465df6d7aabd1065d762
-size 3089848

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191030-060355_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191030-060355_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fad412e5271126023a9a06c6faddbf9256c3f45c2e28c6dbe919bf3dd1a9d306
-size 3092646

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191031-060349_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191031-060349_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b0b8bdbd67c17d89afcaf17ae64e95d2556e5728d8825b48ab06cb8de1fe5ed
-size 3090188

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191101-060346_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191101-060346_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae9ef469d553cdd82bd81817566ef459f24d6ebe3bb93eb59043f5b8e8e11e5c
-size 3090240

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191102-060340_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191102-060340_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86db8080077eb57bb2ecd0b478c581e99b889339915a2ef15179459eeb6df5f0
-size 3090962

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191103-060346_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191103-060346_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:950335b8f80de5de30866edc7819e614933024d93870ec213529d42e34b0b30e
-size 3091254

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191104-060354_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191104-060354_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21a2d8a2eeac05874e773bc9ddc047a490309ef2075b33d1a267b4b495b94fdf
-size 3090732

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191105-060402_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191105-060402_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0207cddcf857d75e812d857baab3615dcd5cf0fb0587b72d07f024cf39693eb8
-size 3091794

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191106-060355_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191106-060355_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2668af3e1192f00bd62266ffd0686863e899ed1f02a93bc59ceaca313650f84c
-size 3091858

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191107-060401_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191107-060401_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9ded68d239075295836bc5df3a6fd070411a8a3dd0fd96d51be0f0c91189c1b
-size 3091758

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191108-060427_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191108-060427_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:403c72680d5d07d47e9950f310daeed612ce9cb6bb3391b0afbc11b08cb53ca9
-size 3090480

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191109-060355_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191109-060355_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd0eb3ed4061774a2133c7a084325c51d5bf197173aee46851274024ea70339d
-size 3090850

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191110-060345_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191110-060345_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a6dc891e6783625fe9465a229325783307c43166dc4ef33f425ed1717658c1a4
-size 3090852

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191111-060347_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191111-060347_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:31f41f954b17af2034107a04f87b9304712c98b1819c126ff4220f5a0c119757
-size 3092492

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191112-060359_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191112-060359_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a134bb7adea67adfcfb2d36c63c6ffbe19861e1fcf69c6441313138873e7f5c
-size 3090392

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191113-060345_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191113-060345_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d07d38886f1298ebb0160ee56037c971dcccc6676ced1d5a7b2c9674277f75bc
-size 3091032

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191114-060348_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191114-060348_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6ca6395ead20791cd003a736fd6f34ed302335c89012330b67a20382e6da279
-size 3093154

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191115-060354_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191115-060354_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13b057f682693dd145043c8a3b8d889e5a50376ac6fd548851233796268ec92b
-size 3091362

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191116-060343_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191116-060343_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57aa890606b954befb51456088a840e36c5838bf929b591783b5481a45c721ad
-size 3091728

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191117-060359_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191117-060359_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9aa1e53666969053be3c4081da4d9cdc345a05652d05b0ca47807937e11fc87
-size 3091352

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191118-060342_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191118-060342_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3b0e5499978ce1cdc006c8adacc45cfbe80e4199bb2021bc5c676f92fa19f6a
-size 3091132

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191119-060426_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191119-060426_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:215d1aa00c535417756ed6056d6fb5a505b17057c7304e09a4ac4dd3ba58f771
-size 3091062

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191120-060350_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191120-060350_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e25b44f78c307c771f03be16b8519a664cdcba977c74bc56c2580843aeefe3dc
-size 3091080

--- a/workstation/stretch/securedrop-proxy_0.1.4-dev-20191121-060350_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.4-dev-20191121-060350_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a094ee899fc55cdad2c479fd6705b592314eb5b017161e5fb71ee29552e78362
-size 3091154

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191204-224236_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191204-224236_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6310c652b8e2ae249f35a505376a726f6604ac82fcd52b0fee7e0fb31881f5be
-size 3091486

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191204-225909+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191204-225909+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fdc25da8745c52186a727a8344852c05b7f38d9d44f5b473a9228fb3216b302
-size 3091608

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191206-060402+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191206-060402+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3028ef2c1e3631e8d7abe42e72368aae555eb88b6de63f4b71977fd13479d46b
-size 3091244

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191207-060445+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191207-060445+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5ab7824ca56d84f496a179b10a1a1fbcef94a24da8c53781e4ebc2f3a5f32af
-size 3090876

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191208-060337+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191208-060337+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7bb86ec88089c2ba47072d44e695a5b0163323201fb5398ebfa749844890d5a3
-size 3091678

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191209-060350+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191209-060350+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d4684cc48b465286efc037c583b0b3b2dd8afe1072addc01d8a8564c45b2bf3
-size 3090860

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191210-060348+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191210-060348+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25730d8fa5a5d2f3161191e736da681da99a1830e95324e519346f5387c0daad
-size 3091812

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191211-060411+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191211-060411+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f010b1601c1072a880f80d8c797d24519489976d31960f2e9819428baa9b244
-size 3092640

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191212-060402+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191212-060402+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6aff574506fbb3e9983ceb1c555bd6a14fabb7a7d16960f87af0e143ce8d2f95
-size 3090914

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191213-060350+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191213-060350+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae98a7fa785d0b01b50af5c664871fbdd6dc27a8792798544d88f0dd9f9840fc
-size 3091050

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191214-060344+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191214-060344+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:240b61c8f1005acf65e3224e358b9f69c23fbf5ba6a84b67d046223d5aebc42e
-size 3091152

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191215-060342+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191215-060342+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfb7ba3c481610c37fdc85ee7e34096eb8342a1bc142345dd36a11a82fc65ca0
-size 3091140

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191216-060348+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191216-060348+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca402edf0cb44b999d1650820c67dc4a70639b67556712921930bcd2c9ff5767
-size 3092048

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191217-060404+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191217-060404+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5312e19b60cf7a870fb291611eff74e193b0caa7f276f9e7460a1560cc74a53a
-size 3091742

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191218-060404+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191218-060404+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd412b1b1b5d5adf5605423e1da06ca0c91d3c335bdb7684be5d62b3c88d6a9c
-size 3090744

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191219-060342+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191219-060342+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4ae7a33e6f43c0757ff8de64e7e512d185220f6edc2a16a856c0bddafa833f0
-size 3091566

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191220-060353+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191220-060353+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d58a989b446eebe7edecc4573478cc235825e43a3ab11162ddfaa3554b07a922
-size 3092420

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191221-060405+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191221-060405+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee99c5d9dbccf9452685adaefd4470e69b7ebe07100f2fb7f681ad305d531990
-size 3092652

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191222-060337+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191222-060337+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b0446f394071c748863a194dd8cfa8dca29822e5ebb1f4c26792ec703b9ce70
-size 3091656

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191223-060349+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191223-060349+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10b53af42068df38f59d53a1d537a09bf3a412e4f6b1703bf09f9f11aad95a3d
-size 3091872

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191224-060403+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191224-060403+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b8a22d346c354c7a8f00003dd5d8a9108a892fa003047d7e6ddf8282432e62b
-size 3092286

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191225-060356+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191225-060356+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:685e43cf9ac9248d1ec0de199047a5793b0ca6f811fa4b1f764cf649a3d50e8f
-size 3091734

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191226-060346+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191226-060346+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28db4dd576f4c33fd95e8a57a41aaa13feec882ee5b5a27b6381b095c3a78916
-size 3091190

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191227-060349+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191227-060349+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99fa3ad71b2979cac5d4eb3b7fed6d19b3c8967879e07860e06e88e30444717e
-size 3090626

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191228-060358+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191228-060358+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85fa3ecb34cab0f575a4c56518d57c1cc84b32147b9795b541aeb2a88f5ebf12
-size 3090936

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191229-060348+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191229-060348+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f79dc7124be9c1efd3a6b76aa8ac8c3137be8e81298e6c6548705f8b14b61cc
-size 3092132

--- a/workstation/stretch/securedrop-proxy_0.1.5-dev-20191230-060336+stretch_all.deb
+++ b/workstation/stretch/securedrop-proxy_0.1.5-dev-20191230-060336+stretch_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6750148f34a5c18f2924d3162570e03b775c439bc356a926a8877983c6dd3e19
-size 3091620


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/424

## Status

Ready for review

## Description of changes
Bumps the version for release, should be a no-op.  packaging changes and logs:
* https://github.com/freedomofpress/securedrop-debian-packaging/pull/140
* https://github.com/freedomofpress/build-logs/commit/449f7c8c253390b2415ece028f37dfdc868f1291

## Test plan
- [x] Removing packages should not cause any server side lfs issues
- [x] Checkout securedrop-debian-packaging
- [x] PKG_VERSION=0.1.2 make securedrop-workstation-config
- [x] sha256 sum of the built package is identical to the one committed here.

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

