### PR TITLE
SecureDrop core packages for 1.2.1-rc1

### DIFF
--- a/core/xenial/securedrop-app-code_1.2.1~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.2.1~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d67e361053ec36d5be9a04a711d14ef7006159dfda9c4aa1be1c6ea1f893681b
+size 12537088

--- a/core/xenial/securedrop-config-0.1.3+1.2.1~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.2.1~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23c308c4992a6a519ff4ee102ada038448dfd9d05911f65040de6c930f1eb992
+size 2742

--- a/core/xenial/securedrop-keyring-0.1.3+1.2.1~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.2.1~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50cedc6d2d31a5f67280eda0415dfe02a8c7f9d8d98a4a87cb2c64abf9dd52aa
+size 4740

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.2.1~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.2.1~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25d5c47f5f4ce9755aa77d88ed223e99b3922006b5da9cfffa55900390386729
+size 3572

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.2.1~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.2.1~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ddedc980bf2bacb9ffdf372432743c37644a7e07cbf2624d9d0f4ff82462b7f
+size 6610


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

1.2.1-rc1 packages. Build logs at https://github.com/freedomofpress/build-logs/blob/master/core/20200214-securedrop-1.2.1-rc1

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

