### PR TITLE
SecureDrop 1.2.2-rc1

### DIFF
--- a/core/xenial/securedrop-app-code_1.2.2~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.2.2~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce93d0d04bb58b8b4cb5cff9fa7173ea671e3e35ac83cbe336116c4681485ad
+size 12554952

--- a/core/xenial/securedrop-config-0.1.3+1.2.2~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.2.2~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd659482fac69dc471af3df05e35cfbdd1ea90cbedcbb1ef363da85f7f7cdaba
+size 2732

--- a/core/xenial/securedrop-keyring-0.1.3+1.2.2~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.2.2~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51e2d26e9897025040d70f52ad60756b189f34e44b1d55c1d8f02e82489ee436
+size 4750

--- a/core/xenial/securedrop-ossec-agent-3.0.0+1.2.2~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.0.0+1.2.2~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55fb34e3bde1019f014bb036d0327738e550ddf68eb5117e1c294a2572838946
+size 3586

--- a/core/xenial/securedrop-ossec-server-3.0.0+1.2.2~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.0.0+1.2.2~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b91af6d1c64d9ed01164ca8758bf1dccd9edf1365ac6117506f758d63600b47e
+size 6644


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop/issues/5156

Build logs available here: https://github.com/freedomofpress/build-logs/commit/7bf8ac4b3b1188df79bc88c338d6a5d03f1a98da

## Description of changes

## Checklist

- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

