### PR TITLE
tor: bumps packages to 0.4.2.7-1

### DIFF
--- a/core/xenial/tor-geoipdb_0.4.2.7-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.2.7-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5fdd6b26d4b39c79a9dc0e55f999b64fc6d40f45a7bad005fb02d8a4408cf71
+size 997312

--- a/core/xenial/tor_0.4.2.7-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.2.7-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2da14014c8d71b2244b68cc1910293a49658104720e823c082b8698025c470e
+size 1437854


### PR DESCRIPTION
## Status
Ready for review.

## Description of changes

Refs https://github.com/freedomofpress/securedrop/issues/5070
See related PR & test plan in https://github.com/freedomofpress/securedrop/pull/5192

### Testing

Confirm the checksums of the files presented here are identical to what's available in the prod tor repo. 

Additionally, you can run `make fetch-tor-packages` on https://github.com/freedomofpress/securedrop/pull/5192 and confirm those checksums match exactly, as well. The difference with the make target is that gpg verification will be performed on the release file prior to download. 


## Checklist
I did not add build logs, because we don't build these packages, merely mirror them. The "compare checksums" recommendation above satisfies concerns about package integrity. 

- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

