### PR TITLE
SecureDrop 1.3.0-rc1

### DIFF
--- a/core/xenial/ossec-agent-3.6.0-amd64.deb
+++ b/core/xenial/ossec-agent-3.6.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd09e231d228468fe968a949ab2675f768c8fbff73fa388d38afd5889b57e637
+size 283854

--- a/core/xenial/ossec-server-3.6.0-amd64.deb
+++ b/core/xenial/ossec-server-3.6.0-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:103b2d04e051e5165716c412d8dee89b148c88102f1eaa88e6c8985b7aa174d3
+size 715296

--- a/core/xenial/securedrop-app-code_1.3.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.3.0~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f55e3e0f19e36670ad1d85ebc95bcca27bb3f87c6e77d460f04f56906eae1c3
+size 12515756

--- a/core/xenial/securedrop-config-0.1.3+1.3.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.3.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a58fa935dbca9ace076ed50b38479b0324e9856a0871f3c98a198f0c622b5e2
+size 2738

--- a/core/xenial/securedrop-keyring-0.1.3+1.3.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.3.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da4c932ff9fd7de30cf0613bea411741f7474cea7089e1b6930aa2553c3d06c6
+size 4766

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.3.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.3.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39273c2c2eeec724e166b3a307e76411142c5856f38853f2f6807a4c14896d50
+size 3608

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.3.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.3.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b7d6a604794a1cbf73efc460b9fda571239cedcb22f12b0fc6b9f15bcea8b0c
+size 6658


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop/issues/5205

Build logs available here:https://github.com/freedomofpress/build-logs/commit/d8b6e73fcb416a45dcbf508e0c63c495ecc1b9d4

## Description of changes

Debian packages for 1.3.0-rc1. Note that builder security updates check is failing due to out-of-date image - the builder image has since been updated and this test will pass for subsequent release candidates.

## Checklist

- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).