### PR TITLE
added libevent1 and libpcre2 dependencies for ossec 3.6.0

### DIFF
--- a/core/xenial/libevent-1.4-2_1.4.14b-stable-0ubuntu1_amd64.deb
+++ b/core/xenial/libevent-1.4-2_1.4.14b-stable-0ubuntu1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:712a171fa15841a0cdb28b89b992ca9ce1c90b43d4851df8a4d009023cdeffee
+size 53838

--- a/core/xenial/libpcre2-8-0_10.21-1_amd64.deb
+++ b/core/xenial/libpcre2-8-0_10.21-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81a876ba97eb7a797a320eefd5b56b57df5ecadd64557dea9c20beaf0e6a3db
+size 164942


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Adds libevent1.4-2 and libpcre2-8-0 packages to apt-test, as they are not in the Xenial security channel and would otherwise not be available to cron-apt. Packages were retrieved via `apt download` on a Xenial system.