### PR TITLE
SecureDrop 1.3.0-rc2

### DIFF
--- a/core/xenial/securedrop-app-code_1.3.0~rc2+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.3.0~rc2+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fa1d3ee9c1b1d94f2b21d328f0263f29481865944f7c2f6971f23251e002169
+size 12595580

--- a/core/xenial/securedrop-config-0.1.3+1.3.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.3.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ee5488b6f7d34d84128f4d47f7294b0bde147d3ecc54bd86934a3d3d1f9acc0
+size 2736

--- a/core/xenial/securedrop-keyring-0.1.3+1.3.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.3+1.3.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaeb28670d9ca587104907ae39ee2c17bbdc4f7975a4ab813ced16d1c7339fb9
+size 4768

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.3.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.3.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4982b89c6e4c6b650b024fc809e2fd2aaa50d585a5d5bd548572eb2164f2c9c9
+size 3628

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.3.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.3.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccf43a94bddc95f0dade62d4676505de5616f3e99e6cb127cb18129ee2c2a9bc
+size 6688


### PR DESCRIPTION
## Status

Ready for review
## Description of changes

Adds deb packages for 1.3.0-rc2

- Build logs: https://github.com/freedomofpress/build-logs/commit/bcdf854e068b7fb9e70d6ce0535db6ed7eef1a9e

Note the builder again needs update, per the build logs (though we did it last week, I propose we do it again prior to release)

## Test plan

- [ ] Included build logs contain shasums of packages committed here
- [ ] All necessary packages are included (ossec and kernel metapackage were omitted as they were no-ops)

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

