### PR TITLE
add tor-0.4.3.5 packages

### DIFF
--- a/core/xenial/tor-geoipdb_0.4.3.5-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.3.5-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08f2ab0da789ee599b73d28713fe0b6ffd502be39eb7674b98daf8081731d6f
+size 997080

--- a/core/xenial/tor_0.4.3.5-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.3.5-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb7cc4fa00c54ffdf195a5c02431b034c5c3b083084f2862a96e1a47f4a73bcd
+size 1454542


### PR DESCRIPTION
## Status

Ready for review.

## Description of changes

Adds tor-0.4.3.5 deb packages. 

See https://github.com/freedomofpress/securedrop/pull/5292.

### Testing

Confirm checksums for tor prod packages (https://deb.torproject.org/torproject.org/pool/main/t/tor/tor_0.4.3.5-1_amd64.deb and https://deb.torproject.org/torproject.org/pool/main/t/tor/tor-geoipdb_0.4.3.5-1~xenial+1_all.deb) match the checksums for the pacakges included in this PR. Remember to use `apt` to download the tor prod packages so that the checksums can be verified.

Also, run `make fetch-tor-packages` from the https://github.com/freedomofpress/securedrop/pull/5292 PR branch and confirm checksums of the files downloaded to the build directory match the checksums for the packages included in this PR.
