### PR TITLE
SecureDrop core packages for 1.4.0-rc1

### DIFF
--- a/core/xenial/securedrop-app-code_1.4.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.4.0~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eeed76cf03e82f9299d5eeec5b8da8084dfde777e29a23095bc495c3a2d78827
+size 12545272

--- a/core/xenial/securedrop-config-0.1.3+1.4.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.4.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ba435608d691c760bd274e3a3c49996ea7b4d6b8e3cb88836a7fb4107e48e0
+size 2740

--- a/core/xenial/securedrop-keyring-0.1.4+1.4.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.4.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7762888f69c1e7c3d038615b5f9959d8e7056217b59c4038ef5307838dadf6f3
+size 5840

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.4.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.4.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74cfc57369a5a5997c0ede749fd90a61ecc2bd6ce1ab14f83657cc647e17f055
+size 4536

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.4.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.4.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b0fc3c2432128ab635c5f6389dd041b8961ac37a87d1fe9d8604cbc81457348
+size 7610


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop/issues/5289

Build logs available here: https://github.com/freedomofpress/build-logs/commit/dd2aade3c79da34611fd41ab8b18c61b13de3a1d

## Description of changes

Debian packages for 1.4.0-rc1. Note that builder security updates check is failing due to out-of-date image. The builder image has not yet been updated accordingly, but should be before rc2.

## Checklist

- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).