### PR TITLE
Adds securedrop-keyring package to apt-test

### DIFF
--- a/workstation/buster/securedrop-keyring_0.1.4+buster_all.deb
+++ b/workstation/buster/securedrop-keyring_0.1.4+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d09f48501f8607560d4ce0e8002382b067217465d81aa7ca36aad1674403f519
+size 6960


### PR DESCRIPTION
## Status

Ready for review
Build logs: https://github.com/freedomofpress/build-logs/commit/786eb46672b07b5c635d87a075770b53a0ce3df9
Packaging : https://github.com/freedomofpress/securedrop-debian-packaging/pull/171
Workstation PR: https://github.com/freedomofpress/securedrop-workstation/pull/563

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

