### PR TITLE
Add Tor 0.4.3.6 packages

### DIFF
--- a/core/xenial/tor-geoipdb_0.4.3.6-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.3.6-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:852bcfc1461bc45876d4730c249061400d854a670490c899578c4af4b2aeb83e
+size 996162

--- a/core/xenial/tor_0.4.3.6-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.3.6-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aed04b5c62049a14e67cc664e9c6815fda8e22bfc282170b23e1e56a213ededd
+size 1453522


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Adds Tor 0.4.3.6 packages. 

### Testing

Confirm checksums for https://deb.torproject.org/torproject.org/pool/main/t/tor/tor_0.4.3.6-1~xenial+1_amd64.deb and https://deb.torproject.org/torproject.org/pool/main/t/tor/tor-geoipdb_0.4.3.6-1~xenial+1_all.deb match the checksums for the packages in this PR. 

Also, run `make fetch-tor-packages` from the https://github.com/freedomofpress/securedrop/pull/5374 PR branch (this uses `apt`'s automatic package verification logic) and confirm checksums of the files downloaded to the build directory match the checksums for the packages included in this PR.