### PR TITLE
remove libevent and libpcre2 packages

### DIFF
--- a/core/xenial/libevent-1.4-2_1.4.14b-stable-0ubuntu1_amd64.deb
+++ b/core/xenial/libevent-1.4-2_1.4.14b-stable-0ubuntu1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:712a171fa15841a0cdb28b89b992ca9ce1c90b43d4851df8a4d009023cdeffee
-size 53838

--- a/core/xenial/libpcre2-8-0_10.21-1_amd64.deb
+++ b/core/xenial/libpcre2-8-0_10.21-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b81a876ba97eb7a797a320eefd5b56b57df5ecadd64557dea9c20beaf0e6a3db
-size 164942


### PR DESCRIPTION
## Status

Ready for review 
Closes https://github.com/freedomofpress/securedrop/issues/5312

## Description of changes

Removed upgrade-path dependency packages, `libevent` and `libpcre2`, now that we no longer provide an upgrade path from 1.2.2 with the release of SecureDrop 1.5.0.

## Test plan

Once this PR is merged, reprepro will automatically run and update the apt server metadata (and also automatically sign the release file with the apt-tst key) so that the packages are no longer on our apt-test server. To test this, wait about 10-20 minutes before checking that:

- [ ] `libevent1` is no longer available here:  https://apt-test.freedom.press/pool/main/libe/
- [ ] `pcre2` is no longer available here:  https://apt-test.freedom.press/pool/main/p/