### PR TITLE
Add SecureDrop core 1.5.0-rc3 packages

### DIFF
--- a/core/xenial/securedrop-app-code_1.5.0~rc3+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.5.0~rc3+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b914e8f8c47b5ca06609f7afc98d6a385e763238fed4236ebe9cc1521260bede
+size 12826410

--- a/core/xenial/securedrop-config-0.1.3+1.5.0~rc3-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.5.0~rc3-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f3ebbf3cbe8c86c65a71900622880af314fc725f13e80b0b0f0b9570aab2069
+size 2742

--- a/core/xenial/securedrop-keyring-0.1.4+1.5.0~rc3-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.5.0~rc3-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c976f9a32ab8c1f2c63e2d38118b412f0c358b4d378dff0b06deef44d327e266
+size 5826

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.5.0~rc3-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.5.0~rc3-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b07a60d4c232680fa0c9e6c8894b723c7df923d314229e21df4d3dbfbe995d7f
+size 4546

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.5.0~rc3-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.5.0~rc3-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eecf542c3a83d4aa4ed466ac4b644dcb95eec1fb3c4959c4dbdfb41ed451e5ee
+size 7620


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop/issues/5368

Build logs available here: https://github.com/freedomofpress/build-logs/commit/3d3c3657b12a852260149b1b02c7e8dbb1d720d5

## Description of changes

Debian packages for 1.5.0-rc3.

## Checklist

- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).