### PR TITLE
Adds Focal channel to apt-test repo

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -3,7 +3,15 @@ Codename: xenial
 Components: main
 Architectures: amd64
 ValidFor: 6m
-Description: SecureDrop server packages
+Description: SecureDrop server packages (xenial)
+SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
+
+Origin: SecureDrop
+Codename: focal
+Components: main
+Architectures: amd64
+ValidFor: 6m
+Description: SecureDrop server packages (focal)
 SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
 
 Origin: SecureDrop


### PR DESCRIPTION
## Status

Ready for review. Closes #56 


## Description of changes


Docs another distribution, Ubuntu Focal 20.04, related to
https://github.com/freedomofpress/securedrop/issues/4768

No packages exist yet, but created the directory in advance.


## Testing

We don't have any Focal packages yet, so the directory is just a placeholder. Once we start uploading focal packages to this repo, we can monitor for automatic changes to https://apt-test.freedom.press/ and confirm it's working well. 
