### PR TITLE
Adds SDW kernel metapackage 4.14.186+buster2

### DIFF
--- a/workstation/buster/securedrop-workstation-grsec_4.14.186+buster2_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.186+buster2_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4791a6a3120d3a85501ff2e4c5532bbab01813d5ef8de62b57f79a1fda944fea
+size 3584


### PR DESCRIPTION


## Status

Ready for review

## Description of changes
Includes changes from
https://github.com/freedomofpress/securedrop-debian-packaging/pull/189

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/189
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/1ba0ccfad1bd67f6aea32a8d7407a8d5b8e405fb
- [ ] Checksum of package matches what's in the build logs

