### PR TITLE
Adds Focal packages: tor & kernels

### DIFF
--- a/core/focal/linux-headers-4.14.188-grsec-securedrop_4.14.188-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-4.14.188-grsec-securedrop_4.14.188-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f9009098293b9530beced524a66004d50f6657ef0fad99a5d404b8ff2520a38
+size 17931224

--- a/core/focal/linux-image-4.14.175-grsec-securedrop_4.14.175-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-4.14.175-grsec-securedrop_4.14.175-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b219769e6d68151aec07dc3b076455a6b612b5c2314876241730c0459a3e2ba
+size 53487466

--- a/core/focal/linux-image-4.14.188-grsec-securedrop_4.14.188-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-4.14.188-grsec-securedrop_4.14.188-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c66be763f3d781e3b9e38dbc52f7853634bf555934984b7a79aa05bb3f8f264
+size 50825238

--- a/core/focal/tor-geoipdb_0.4.3.6-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.3.6-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a221c94f0c9ba9c82e47822482b082ec3500c4ae298385e1dddd5467aa4301ca
+size 1000904

--- a/core/focal/tor_0.4.3.6-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.3.6-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42b98af8cabe13a1bab6213a3fdfa1f31388acdb9cc9275e3cb972c8b5333bd0
+size 1453992


### PR DESCRIPTION
## Status

Ready for review 

Refs https://github.com/freedomofpress/securedrop-dev-packages-lfs/issues/59

## Description of changes

* Adds tor packages for focal, fetched via the new logic in https://github.com/freedomofpress/securedrop/pull/5482
* Adds kernel packages for Focal (image & header)
    
Reusing the xenial kernel packages for Focal so that we have a baseline to work from. We may end up shipping 5.x kernels soon, but we're still working on building out Focal support.
  
What's missing here is the "securedrop-grsec" metapackage for Focal. We don't have a unique version string for the metapackage, including a platform such as +xenial or +focal, so we'll have to add some logic to support the package.

Also haven't added the other Focal packages built in the SD repo, so https://github.com/freedomofpress/securedrop-dev-packages-lfs/issues/59 remains open to track. 


## Checklist
No build logs are included, because these packages weren't newly built by us. The kernels are the same, and the tor packages are fetched from upstream. So, to review:

- [ ] https://github.com/freedomofpress/securedrop/pull/5482 is approved
- [ ] The checksums for the kernel packages are identical to those hosted under the `core/xenial/` dir.

