### PR TITLE
Copies kernel metapackage Xenial -> Focal

### DIFF
--- a/core/focal/securedrop-grsec-4.14.188-amd64.deb
+++ b/core/focal/securedrop-grsec-4.14.188-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c79e0e76043a67f766d87f4028aed6d2d853e1d97595ad0f926f4851940b4b0a
+size 2300


### PR DESCRIPTION


## Status

Ready for review 

## Description of changes

Towards https://github.com/freedomofpress/securedrop-dev-packages-lfs/issues/59

In order to provide Focal support, we must ensure that the `securedrop-grsec` metapackage is available via apt, so that the kernel image will be pulled in according to that package's dependencies.

This change copies the exact same metapackage already used for Xenial into the Focal channel.



## Checklist
- [ ] The packages at `core/xenial/securedrop-grsec-4.14.188-amd64.deb` & `core/focal/securedrop-grsec-4.14.188-amd64.deb` are identical, i.e. have the same checksum.

