### PR TITLE
Adds Tor 0.4.4.5 packages for Xenial and Focal

### DIFF
--- a/core/focal/tor-geoipdb_0.4.4.5-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.4.5-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8f1c7ca4ce517c5abf2542815977c2439e185c8d6176c16dca6f088daa1fe49
+size 999904

--- a/core/focal/tor_0.4.4.5-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.4.5-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b37e533f6fc4588332d67cd7cc0cad8e852060fe4b9626415d0dd14dc20908f4
+size 1462280

--- a/core/xenial/tor-geoipdb_0.4.4.5-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.4.5-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c767c8e3597c2e2a659ac19116fe64c030b4ff00b31dd1e82d6ee4478a4b024e
+size 984634

--- a/core/xenial/tor_0.4.4.5-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.4.5-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e6a90acc52799bfb3f84222ab7955fa567c04eae974d7a7a9a62494d662a822
+size 1461284


### PR DESCRIPTION

## Status 
Ready for review
## Description of changes
This is now tracking Tor's 0.4.4.x series which will be supported until June 2021 and contains performance and security fixes.

## Test plan
See https://github.com/freedomofpress/securedrop/pull/5502
