### PR TITLE
Adds debs for SecureDrop 1.6.0-rc1

### DIFF
--- a/core/xenial/securedrop-app-code_1.6.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.6.0~rc1+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da3fbc3260ae30df4e0b40b47f847ded67d5aab75147c80d0a7f645059573d5e
+size 10534722

--- a/core/xenial/securedrop-config-0.1.3+1.6.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.6.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9455d47ea88e165c577d55ccfcbae4b66fb96d76b02c02694b4dfdf576cdb3e6
+size 2732

--- a/core/xenial/securedrop-keyring-0.1.4+1.6.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.6.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d342fdd674e69b91f70a7fcde1766e0c12ac41f52ac322f3f72639affef20a85
+size 5840

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.6.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.6.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dc70703a397b1d0d66797ff8d0e5cd3b5f989ca5bf6ed40ee28cb1682642965
+size 4566

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.6.0~rc1-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.6.0~rc1-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5582da48ab643c31f897b09157a6ddd7279ed1c8a0e25da99fa445b3b76cebe2
+size 7648


### PR DESCRIPTION
## Status

Ready for review

## Description of changes
Provides SecureDrop 1.6.0-rc1 packages, towards https://github.com/freedomofpress/securedrop/issues/5501
Build logs:
https://github.com/freedomofpress/build-logs/commit/3666cc4378e922548754f09e511f7645ef28088a
## Checklist

- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

## Test plan

- [ ] 1.6.0-rc1 tag is correct (https://github.com/freedomofpress/securedrop/releases/tag/1.6.0-rc1)
- [ ] hashes of debs correspond to those in build logs 
