### PR TITLE
Add template-consolidation component for buster 

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -24,7 +24,7 @@ SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
 
 Origin: SecureDrop
 Codename: buster
-Components: main
+Components: main template-consolidation
 Architectures: amd64
 ValidFor: 6m
 Description: SecureDrop Workstation packages (buster)

--- a/workstation/template-consolidation/securedrop-proxy_0.3.1+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-proxy_0.3.1+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:104629824307f98e888fc94c53d9d56c4f0c5a55f3ef47f907a16c536cfdb55f
+size 4884632

--- a/workstation/template-consolidation/securedrop-workstation-viewer_0.1.0+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-workstation-viewer_0.1.0+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57b2b75c60f04b62351f753baebb00e240981850fa646891d2e55241374083de
-size 1584

--- a/workstation/template-consolidation/securedrop-workstation-viewer_0.1.0+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-workstation-viewer_0.1.0+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b2b75c60f04b62351f753baebb00e240981850fa646891d2e55241374083de
+size 1584

--- a/workstation/template-consolidation/securedrop-workstation-viewer_0.1.1+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-workstation-viewer_0.1.1+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25b7c8956c43b023b68a79a4de409ec0acf199d7f6af4610e3770fb38f5fe1b0
+size 1636


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Using a dedicated "component" so that we can isolate ongoing development
specifically on template consolidation work [0] so that we can evaluate
upgrade behavior. While it's frankly acceptable to break "apt-test"
packages temporarily, we need the ability to test before/after states to
evaluate behavior during upgrades. Thus the separate component.

Requires updates to the CD logic that runs on apt-test.

Towards https://github.com/freedomofpress/securedrop-workstation/issues/471

Contains newly built packages based on changes in https://github.com/freedomofpress/securedrop-debian-packaging/pull/198

## Checklist
- [x] Confirm newest `securedrop-proxy` version available in the "main" pool is some nightly of 0.3.0: https://apt-test.freedom.press/pool/main/s/securedrop-proxy/ 
- [x] Confirm newest `securedrop-proxy` version available in the "template-consolidation" pool is at least 0.3.1 (included in this PR): https://apt-test.freedom.press/pool/template-consolidation/s/securedrop-proxy/

Confirming the above, since apt-test is currently tracking this feature branch, is essentially verifying the following apt cache output:

```
securedrop-proxy:
  Installed: (none)
  Candidate: 0.3.1+buster
  Version table:
     0.3.1+buster 500
        500 https://apt-test.freedom.press buster/template-consolidation amd64 Packages
     0.3.0-dev-20201005-060258+buster 500
        500 https://apt-test.freedom.press buster/main amd64 Packages
```

except you don't have to mangle your apt sources locally. 