### PR TITLE
Adds deb packages for SecureDrop 1.6.0-rc2

### DIFF
--- a/core/xenial/securedrop-app-code_1.6.0~rc2+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.6.0~rc2+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f1e89ddbdaaf790aad3226cbd89e917f1e84356e8bca8d46841e66d0e4a5031
+size 10534234

--- a/core/xenial/securedrop-config-0.1.3+1.6.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.6.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c415e929e5983a9c23f798083ff9a1ceb6e61fafe6047763cfe8d9b8e447f265
+size 2736

--- a/core/xenial/securedrop-keyring-0.1.4+1.6.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.6.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:500b9ecdbd593d4344f55e13dbdc386c66466dc78364b6d54eb8690e35416b0b
+size 5840

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.6.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.6.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:716acbba95de0a81400a37f1c01a5e0cf036e7afa8a336f8c7442d3e61dd224a
+size 4568

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.6.0~rc2-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.6.0~rc2-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bad22c0d65771b4fc1619fab1e163a8fbe5798e654c2594561b55202314c33b
+size 7644


### PR DESCRIPTION
## Status

Ready for review


## Description of changes
Towards https://github.com/freedomofpress/securedrop/issues/5501
- [x] tag is correct https://github.com/freedomofpress/securedrop/releases/tag/1.6.0-rc2
- [x] Package hashes are correct 
## Checklist

- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) https://github.com/freedomofpress/build-logs/commit/5b7fad643ca5bf6d6eb1138188a9981ebc496e98

