### PR TITLE
Adds securedrop-export 0.2.4 rc pkg

### DIFF
--- a/workstation/template-consolidation/securedrop-export_0.2.4+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-export_0.2.4+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8b15f56c96ad7ba9fbd1ef1440894d92838ae87abbc1b9da6a2bc54f709745c
+size 4568652


### PR DESCRIPTION

## Status

Ready for review 

## Description of changes

Removes mimetype associations, incorporating changes from PR

https://github.com/freedomofpress/securedrop-export/pull/65

Not including build logs since we'll rebuild all of the packages in the "template-consolidation" channel after testing and review. Part of the epic https://github.com/freedomofpress/securedrop-workstation/issues/471
