### PR TITLE
Rebuilds proxy for template-consolidation

### DIFF
--- a/workstation/template-consolidation/securedrop-proxy_0.3.1+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-proxy_0.3.1+buster_all.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:104629824307f98e888fc94c53d9d56c4f0c5a55f3ef47f907a16c536cfdb55f
-size 4884632
+oid sha256:f4ff98dff0b35e283b071f39187e2c223f1891147182ba192befb335f3d5b7d0
+size 4876488


### PR DESCRIPTION


## Status

Ready for review 

## Description of changes
Incorporated newer build dependencies, see discussion in
https://github.com/freedomofpress/securedrop-proxy/pull/79#pullrequestreview-511972118

## Checklist
No build logs because specific to template consolidation (https://github.com/freedomofpress/securedrop-workstation/issues/471). Visual review is sufficient.

