### PR TITLE
Rebuilds client for template-consolidation

### DIFF
--- a/workstation/template-consolidation/securedrop-client_0.2.2+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-client_0.2.2+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a732edd08a7cce4cc7ef212d1d895ab2d26c4475f74906c3f83cc42d8b9df913
+size 7755844


### PR DESCRIPTION

## Status

Ready for review

## Description of changes
Removes mimetypes from the securedrop-client package, given that they're now provided in
`securedrop-workstation-config`. See corresponding changes in:

  * https://github.com/freedomofpress/securedrop-client/pull/1160
  * https://github.com/freedomofpress/securedrop-debian-packaging/pull/198

## Checklist

No build logs because specific to template consolidation (freedomofpress/securedrop-workstation#471). Visual review is sufficient

