### PR TITLE
Rebuilds sdw-config for template-consolidation

### DIFF
--- a/workstation/template-consolidation/securedrop-workstation-config_0.1.5+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-workstation-config_0.1.5+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3ca50232c715195a4f4b78f4aee85aa9ff5dbb0ae55da778d29187d3138086a
+size 5300


### PR DESCRIPTION

## Status

Ready for review 

## Description of changes

Adjusts mimetypes handling, consolidating into a single package as much
as possible. See:

https://github.com/freedomofpress/securedrop-debian-packaging/pull/198


## Checklist
No build logs because specific to template consolidation (freedomofpress/securedrop-workstation#471). Visual review is sufficient