### PR TITLE
Rebuilds packages for template-consolidation

### DIFF
--- a/workstation/buster/securedrop-workstation-config_0.1.5+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.5+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3ca50232c715195a4f4b78f4aee85aa9ff5dbb0ae55da778d29187d3138086a
+size 5300

--- a/workstation/buster/securedrop-workstation-viewer_0.1.1+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-viewer_0.1.1+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dd5e3e10d202cbf90639988543ae8ed979b97b82283a0e4dfa91620301470db
+size 1636

--- a/workstation/template-consolidation/securedrop-client_0.2.2+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-client_0.2.2+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a732edd08a7cce4cc7ef212d1d895ab2d26c4475f74906c3f83cc42d8b9df913
-size 7755844

--- a/workstation/template-consolidation/securedrop-export_0.2.4+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-export_0.2.4+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8b15f56c96ad7ba9fbd1ef1440894d92838ae87abbc1b9da6a2bc54f709745c
-size 4568652

--- a/workstation/template-consolidation/securedrop-proxy_0.3.1+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-proxy_0.3.1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4ff98dff0b35e283b071f39187e2c223f1891147182ba192befb335f3d5b7d0
-size 4876488

--- a/workstation/template-consolidation/securedrop-workstation-config_0.1.5+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-workstation-config_0.1.5+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3ca50232c715195a4f4b78f4aee85aa9ff5dbb0ae55da778d29187d3138086a
-size 5300

--- a/workstation/template-consolidation/securedrop-workstation-viewer_0.1.1+buster_all.deb
+++ b/workstation/template-consolidation/securedrop-workstation-viewer_0.1.1+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25b7c8956c43b023b68a79a4de409ec0acf199d7f6af4610e3770fb38f5fe1b0
-size 1636


### PR DESCRIPTION
## Status

Ready for review

## Description of changes
Rebuilds two (2) packages after merge of

Also removes template-consolidation testing debs. These debs were published to a dedicated "template-consolidation" channel to aid in testing. We're now proceeding with testing against apt-test main, where the nightly packages will be available. Removing these since several had their versions bump, and they'd supersede the nightlies.


## Checklist

Note: we haven't tagged the packaging repo yet, so the build logs below don't include verification of sigs for component code. 
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/198 
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): 
  - https://github.com/freedomofpress/build-logs/commit/62d228fdfa282127ea42c59129fb9a904e49efaa
  - https://github.com/freedomofpress/build-logs/commit/ff73426a121a371681a9ee1a937c8db35cdc4aa5

