### PR TITLE
add client deb for workstation 0.5.0 release qa

### DIFF
--- a/workstation/buster/securedrop-client_0.3.0-dev-20201105-368730+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.3.0-dev-20201105-368730+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffa584be89155c8305b4e5209a401006d8420062ada17deed3afc347a5e3624c
+size 7761900


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Adds securedrop-client package to include data migration in https://github.com/freedomofpress/securedrop-client/pull/1184 

## Checklist

Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/blob/main/workstation/securedrop-client-0.3.0-dev-20201105).

