### PR TITLE
Adds 5.4.88 kernels for Focal

### DIFF
--- a/core/focal/linux-headers-5.4.88-grsec-securedrop_5.4.88-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.4.88-grsec-securedrop_5.4.88-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb6b001c6d8b672192a47a359f8c61f9d4ec634c8b9ee9325d06858f389846d0
+size 23591196

--- a/core/focal/linux-image-5.4.88-grsec-securedrop_5.4.88-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.4.88-grsec-securedrop_5.4.88-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:074ada54fb5e70b42fe298825b6bbc0cce745118a8f20c00e30e9436e5cea89a
+size 52716284


### PR DESCRIPTION
## Status

Ready for review

## Description of changes
Towards https://github.com/freedomofpress/securedrop/issues/5479. This adds new 5.4.x kernels, built for SecureDrop servers, with the pre-existing patches already present for older model hardware support.

These do *not* include additional patches for e.g. NUC10 support. Will rebuild once those are ready.

Uses new logic in https://github.com/conorsch/kernel-builder/ , which also permits saving build logs. 

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging) uses logic in 
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/ec1d27c506d423a8c5698ab38fcc1c0e0e71c2d3

