### PR TITLE
SecureDrop 1.7.0-rc4 (Xenial)

### DIFF
--- a/core/xenial/securedrop-app-code_1.7.0~rc4+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.7.0~rc4+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a04923226811f5a3f14279124d973063206382128fe1c2b841a9e6a5684c8d06
+size 10506882

--- a/core/xenial/securedrop-config-0.1.3+1.7.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.3+1.7.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee56985719faa9fe8dc1e614f9d2fd454ce4d3b48d840c454188bc9617cf5a4f
+size 2740

--- a/core/xenial/securedrop-keyring-0.1.4+1.7.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.7.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50d5517748b150e001f004cc14aab952ea8df5565dc905f6d0805f7b776c8669
+size 5836

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.7.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.7.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20d9028f8ab10d91a3a5d5b6240da1958de18b1084f147d2c898e633c9f538fb
+size 4592

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.7.0~rc4-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.7.0~rc4-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7dacfe380c9c10572e5c76da7df53483e18f19852c9a0bbe14921aeb311ba44
+size 7864


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

Adds deb packages for SecureDrop 1.7.0-rc4, based on https://github.com/freedomofpress/securedrop/pull/5738. Only adding Xenial packages, skipping Focal due to https://github.com/freedomofpress/securedrop-dev-packages-lfs/issues/85.

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging) - https://github.com/freedomofpress/securedrop/pull/5738
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) - https://github.com/freedomofpress/build-logs/commit/5b4ab1ce4c1a4d3b5e47e2e1469a1faa0e4f02fc

