### PR TITLE
Adds securedrop-grsec 5.4.88 package for Ubuntu Focal

### DIFF
--- a/core/focal/securedrop-grsec-5.4.88+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.4.88+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad4cf81a5204f9b2fe42f8c4ef421a9a8b1dd3e854d0cc7629034f8a4c6136f5
+size 2960


### PR DESCRIPTION
## Status

Ready for review, should only be merged once https://github.com/freedomofpress/securedrop/pull/5772 is approved.

## Description of changes

Provides an updated metapackage for Ubuntu Focal that will install a 5.4.88 kernel, see https://github.com/freedomofpress/securedrop/pull/5772 . The kernel image was already merged in #81.

