### PR TITLE
Adds securedrop-config 0.1.4 package for focal

### DIFF
--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7b7fd312e8d920519ec34cc04c419550ffc08199c1ca66632b7e364a44e93fa
+size 2848


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Provides a focal-only update to the securedrop-config package, which contains the files required to configure unattended-upgrades. This includes the changes introduced in https://github.com/freedomofpress/securedrop/pull/5684

