### PR TITLE
Adds 5.4.97 kernel for Focal

### DIFF
--- a/core/focal/linux-headers-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a724f42e8093fc33b252a559304c327f81ec5f67f4c592a0cabb0e1c43687d2
+size 24125572

--- a/core/focal/linux-image-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c00a4de094188c56c53e616ee3abb281d4b58207e6d7b1ef8249c21a51d2c34
+size 53224848


### PR DESCRIPTION
## Status

Ready for review  

## Description of changes

## Checklist
- [x] Cross-link to changes made in [SD repo](https://github.com/freedomofpress/securedrop): https://github.com/freedomofpress/securedrop/pull/5785
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/cdeea2ec9b77e18e0c10b72d9b63ab7648af691e
- [x] Source tarball has been uploaded to relevant bucket: linux-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop.orig.tar.gz
- [x] Kernel config is version-controlled: https://github.com/freedomofpress/kernel-builder/pull/15

