### PR TITLE
Adds Tor 0.4.5.6 packages for xenial and focal

### DIFF
--- a/core/focal/tor-geoipdb_0.4.5.6-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.6-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6b374634fcafac2c92b932393cadcaa1daa479eacf98212dc18cde786087a11
+size 997760

--- a/core/focal/tor_0.4.5.6-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.6-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:034b71c8e66284bcbe7f684b4054222b404a151fcf8c335eb9edfdcf783d13aa
+size 1486544

--- a/core/xenial/tor-geoipdb_0.4.5.6-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.5.6-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:516d86ac4e401efcae0d3ad46005ef5db4b0acc0fa4d523509e599a0071f2c55
+size 983138

--- a/core/xenial/tor_0.4.5.6-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.5.6-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe12dd3fb39b4e7586905afeaaf301840a8326359b63ef34bfcfcf75587ad602
+size 1485554


### PR DESCRIPTION
## Status

Ready for review
## Description of changes

Provides Tor 0.4.5.6  packages for xenial and focal

Build logs; https://github.com/freedomofpress/build-logs/commit/5bbc480f8791abe117d8044e2098a6925924a5aa
## Checklist

- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/5bbc480f8791abe117d8044e2098a6925924a5aa).

