### PR TITLE
SecureDrop 1.8.0-rc1

### DIFF
--- a/core/focal/securedrop-app-code_1.8.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc1+focal_amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8867c61dcef4ebabbcb39a6bb0f84ff8f25ea3cf6e0ad4abe679b4596bfae52d
-size 10995808
+oid sha256:7455257e1e6ceaafa183da8cd001bb7413b942ad2655601b656a571b2b8c0572
+size 10982064

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7b7fd312e8d920519ec34cc04c419550ffc08199c1ca66632b7e364a44e93fa
-size 2848
+oid sha256:e2deabe337cd49dc449933fedf5cad48279d92505af57ec0cbf0a3423121cb63
+size 2956

--- a/core/focal/securedrop-grsec-5.4.97+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.4.97+focal-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:882981e8fc4dc566a6519d58412258e31cb6e53dd1a5c786fc7205d77fb9178e
-size 2960
+oid sha256:2ffeafc956deb575a4316a0fa90752a260b6e1fc050c8ccf71bf63348bff4248
+size 3000

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7a646d8bbaaeac279677577732606e97363ed4eb46956f8b5cf579353a3f694
-size 5924
+oid sha256:55a58cc24c106a72d2b3e88bb4e0f6ebff961a0794460f0c8bd29e29700e2db4
+size 5928

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e3ce09a16a9087a2d6fa75b340ae3f15a14368812b5e8d4c13196ee5b83bc6c
-size 4660
+oid sha256:808535e24845970cc32c7e32f3f118de313eaae03954df9cfd865deb68c84781
+size 4668

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdb59eac78602b781d84ad7a1a7b87fe1e33414ae58835ac203f3658f0dacb3c
-size 7916
+oid sha256:089fe8e2fba418e7983327e0ce76628edc241d3bc12e7a2722fb12885b4e14c5
+size 7924

--- a/core/xenial/securedrop-app-code_1.8.0~rc1+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.8.0~rc1+xenial_amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:559d00c6128e737abaae0131dfa35b7a5f2a1f062ba4c33536185bbf1e60204d
-size 10493476
+oid sha256:2b8a28e8a83990ec1c6e6867978075cc7e58d9c6678b72f45cfe95a0c2d163b9
+size 10506254

--- a/core/xenial/securedrop-config-0.1.4+1.8.0~rc1+xenial-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.4+1.8.0~rc1+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f727846c67e4c794b4fcb9d693412dd070080b253ce3f2a5d11b0f7d6ec2122
+size 2748

--- a/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc1+xenial-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc1+xenial-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0773f64386454b8a4a8ea3e835077352c0ada5673b757e340c769ddc8a23aaeb
-size 5830
+oid sha256:bd82e4e3e10c7d4b3e65568cbd212a0f5ab48038f8e4b02377347d606e456501
+size 5846

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc1+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc1+xenial-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:452034a32502eb0f512d2c5c7586da1b685c62214336d97aa8d91143fba41fb6
-size 4602
+oid sha256:be51afd44fa4fc0f7ac8b29ba9ce32b8192c23593ba70f2329841d16cec4ca19
+size 4596

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc1+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc1+xenial-amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:630c90fd580b677423a72cee46ee22c197a1398b09d5b2a95721cb6b326304ff
-size 7876
+oid sha256:8487c0204b18eb2d617d162d87ec2c6c5a258c9d25ce4827d32d2d9961f639be
+size 7870


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging). **n/a**
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/0ce458d0ae607f1fd5e090568c24c77b8c404075).
- [x] sha256sum hashes of debs match hashes in the build logs

