### PR TITLE
Adds debs for SecureDrop 1.8.0-rc2

### DIFF
--- a/core/focal/securedrop-app-code_1.8.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a10a9653a2e88fb182bfbf474d2677e989da06a6c1eaa97acfea48d00e1fb9c0
+size 10983688

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c685559a5254637209c54a8aff92a96fb960032ae9bb2a0b0e4db5dd96043305
+size 2960

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:866a961833903d8daed558a87f2968bc94026c6dd48342e28259b2dc6e0c6078
+size 5928

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fd38b59cbc21a7e4f2b26ad09446e9005d86f0ddabe8ce5c53cafc1a88841ee
+size 4664

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df7a813ce5e1265520de6a0bc9417eb3fc83ffc6ee65a552ebfe78616bdea592
+size 7920

--- a/core/xenial/securedrop-app-code_1.8.0~rc2+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.8.0~rc2+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:125299703f22c715e8ad9ca2919735fb616aeaa39d787d7fb6630328d3aa580c
+size 10523072

--- a/core/xenial/securedrop-config-0.1.4+1.8.0~rc2+xenial-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.4+1.8.0~rc2+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2550e93673db132f3244d07341ed1c48624786ca18dd76ebae8ada722949ae0
+size 2742

--- a/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc2+xenial-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc2+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70f98b785c3d7771b860945cd8e1b8c95dbb4f18c2f00f3d4f526c7b40a37e23
+size 5832

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc2+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc2+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:000f5822f24f1e90597f65ded3af50edb97aeaa0a2ba3301b83e3548ff40aa8b
+size 4608

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc2+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc2+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcc1a88b5a0feb86e4c446b92b17fbceec280bd8f381690724bb983e869b92f2
+size 7886


### PR DESCRIPTION
## Status

Ready for review

Build logs: https://github.com/freedomofpress/build-logs/commit/33b894ba6d1cdd45f2381f422f45a119436cccad

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).

