### PR TITLE
SecureDrop 1.8.0-rc3

### DIFF
--- a/core/focal/securedrop-app-code_1.8.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98b74a08c5b4978d7a4b6ce2929beccf9a2ea82f8b3f073feb7cf283af21dbb8
+size 10984360

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c4b1217d383e987f6636ebb8f1ef1b7c681afa729a7ab7ede91f03d6616c41c
+size 3056

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:255e8b9ca77c27d52412fd90422adf1f623952da10d27aa00a0e93afbba89e8b
+size 5928

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25ac29b2fda9975b139b9b670af695f2345dba381ecc523feb177a7ff622128a
+size 4668

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47425d632e6a6852a4328d9e62088ee7aaa626d4ac1ab397856e92e2820105e7
+size 7920

--- a/core/xenial/securedrop-app-code_1.8.0~rc3+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.8.0~rc3+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e7756b88b6c3307e0a75cdf3b1e357a04e9595e49567a1004f3736a8aab7e85
+size 10510584

--- a/core/xenial/securedrop-config-0.1.4+1.8.0~rc3+xenial-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.4+1.8.0~rc3+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae46e5bb47b2f7d930a4f56b872c85aad5594c010c4f9eff07ec421e322f1e2c
+size 2744

--- a/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc3+xenial-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc3+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:338d962ebf8cad78e5c82a4a18a22827155672ef5068a59a119c6a276da1c489
+size 5842

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc3+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc3+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24a0deb8ae91fdb5217b7109734fd0f7a2f02c032229577d263c732a9c581f93
+size 4596

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc3+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc3+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eab7561118f6255eae9d857fc1d243ba01d580658600f2d4f2259ae367f7134
+size 7870


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) - https://github.com/freedomofpress/build-logs/commit/4804a0a36aa2c139183f5691278fa27c8ad4b359.
- [x] Hashes match those in the build log.

