### PR TITLE
Adds pkgs for SecureDrop 1.8.0-rc4

### DIFF
--- a/core/focal/securedrop-app-code_1.8.0~rc4+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc4+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d824211db8bb0e2af7006c3b5e25cf37c067d45297c96d7fad9f034e62732b97
+size 10984808

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c8bed75686e5ceebff31600bb39791e1fccf9804d6821e7940416dae6318ae3
+size 3064

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9121dae4803fa99321b023908ae77318b756aa53883b96c77ab491670c5524e3
+size 5924

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:417e1e36bade19e08b7030bff33e465e8c8f7f878b3d255c26fe8092614285dd
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cebf25282b01142bf45d49bb1c29ed0f66061fd4c101639a72ebfae86bda67ab
+size 7916

--- a/core/xenial/securedrop-app-code_1.8.0~rc4+xenial_amd64.deb
+++ b/core/xenial/securedrop-app-code_1.8.0~rc4+xenial_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d91e9fd63ee43374e56031c0547e64140d84c861e63fc47e37cdf3a892102a2
+size 10506846

--- a/core/xenial/securedrop-config-0.1.4+1.8.0~rc4+xenial-amd64.deb
+++ b/core/xenial/securedrop-config-0.1.4+1.8.0~rc4+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a8d0484aba23f528248e226948a5d97ccc2def0e8dbe73cad7a678942011f3a
+size 2742

--- a/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc4+xenial-amd64.deb
+++ b/core/xenial/securedrop-keyring-0.1.4+1.8.0~rc4+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:973d62e8bfbf3484d28d0180f8a0d61d6e7f2e5c9f37c5c874e9c3f74602aa06
+size 5842

--- a/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc4+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-agent-3.6.0+1.8.0~rc4+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f98f13cb761c8412cf23eec2440fa3fcfab1232fa2c5a5a44578a2f6cefb1b34
+size 4598

--- a/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc4+xenial-amd64.deb
+++ b/core/xenial/securedrop-ossec-server-3.6.0+1.8.0~rc4+xenial-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4763fd4815ccca52c8a002fee034b176cb15557b575417dfaba4ff6a4a840b5
+size 7874


### PR DESCRIPTION


## Status

Ready for review 

## Description of changes

Builds 1.8.0~rc4 debs, for both Xenial & Focal. 

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) - https://github.com/freedomofpress/build-logs/commit/98d454c35afe9ea7c7ce0d2169db771995d6f928

