### PR TITLE
Adds securedrop-workstation-config 0.1.6

### DIFF
--- a/workstation/buster/securedrop-workstation-config_0.1.6+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.6+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba4002770ef698ad7aa56ecbd93f6f14eba4333a489180d2c60b01ed8ee2475a
+size 5640


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging) : https://github.com/freedomofpress/securedrop-debian-packaging/pull/221 & https://github.com/freedomofpress/securedrop-debian-packaging/pull/222
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) - https://github.com/freedomofpress/build-logs/commit/1fc3b684c7b8b66cc558963b719221b7a9be6629

