### PR TITLE
SecureDrop 1.8.0-rc5

### DIFF
--- a/core/focal/securedrop-app-code_1.8.0~rc5+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc5+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f79187a78a101cece123f814db0783deb5e2495f65801f8f9cff821edbc8fa04
+size 10987640

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc5+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d0895f396f51eb2fbf3bf5268f20281d6e88b29253596c0c32ea34613c45027
+size 3064

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc5+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc0823396b56b55bf7c9d5b2847d01ca6f7cbf0f67961880ea7cc76601be7ba
+size 5924

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc5+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c807e6aa0fabcece8f6ae4ea3281e47838e3bb7de43723b611ea795603bd2699
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc5+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd091799abd87fbe1dc2b0250c8ca539aa43782273fcd3f0869cab785041a2e4
+size 7916


### PR DESCRIPTION
## Status

Ready for review 

no-op RC for upgrade testing purposes. Only versions and changelogs are updated.

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/183a92e0ee98fcd71af0c07957ce467a4807a059).
- [x] hashes in logs match those in the PR
- [x] only focal packages are present.

