### PR TITLE
Added Tor 0.4.5.7 packages, removed Tor 0.4.4.* packages.

### DIFF
--- a/core/focal/tor-geoipdb_0.4.4.5-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.4.5-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8f1c7ca4ce517c5abf2542815977c2439e185c8d6176c16dca6f088daa1fe49
-size 999904

--- a/core/focal/tor-geoipdb_0.4.4.6-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.4.6-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0b643f0943732d2fc3c86746629c98a44971df17fc5f73b168570905ea73d7f
-size 1004580

--- a/core/focal/tor-geoipdb_0.4.5.7-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.7-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bafdbf7e088ac95ef15fde48a6a0de5e1650bdbbc11c6468acc6caf82611bd6d
+size 867776

--- a/core/focal/tor_0.4.4.5-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.4.5-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b37e533f6fc4588332d67cd7cc0cad8e852060fe4b9626415d0dd14dc20908f4
-size 1462280

--- a/core/focal/tor_0.4.4.6-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.4.6-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44ca06ceb29082671b4efe1b9ab819095b92ec9e1016e57b46b86e84d84da962
-size 1462760

--- a/core/focal/tor_0.4.5.7-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.7-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd96342207997f805100bc8a429aeecf143f0f7d91b544fc962d438a5cd19184
+size 1486912

--- a/core/xenial/tor-geoipdb_0.4.4.5-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.4.5-1~xenial+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c767c8e3597c2e2a659ac19116fe64c030b4ff00b31dd1e82d6ee4478a4b024e
-size 984634

--- a/core/xenial/tor-geoipdb_0.4.4.6-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.4.6-1~xenial+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d7cd512032bbf2a2a6a3c401986e26825b4852bf6961343dec56c2052f3d372
-size 994202

--- a/core/xenial/tor-geoipdb_0.4.5.7-1~xenial+1_all.deb
+++ b/core/xenial/tor-geoipdb_0.4.5.7-1~xenial+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abcf3d5cf6a61a632032c98b5dbb1749608b00fc13660e9210472933ecc13b81
+size 863570

--- a/core/xenial/tor_0.4.4.5-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.4.5-1~xenial+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e6a90acc52799bfb3f84222ab7955fa567c04eae974d7a7a9a62494d662a822
-size 1461284

--- a/core/xenial/tor_0.4.4.6-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.4.6-1~xenial+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0eceb0386c19cd9e1dd51409aacae21ba0352c716065c8fb2c7858724fb875a1
-size 1461308

--- a/core/xenial/tor_0.4.5.7-1~xenial+1_amd64.deb
+++ b/core/xenial/tor_0.4.5.7-1~xenial+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a555612f9896d4060cee29565d5dc70c6a31a38839d8de7684706a13d7f7ae50
+size 1483936


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/b4b76ad35c9df42fbb1b2a7d3f635305d42a026f 
- [ ] SHA256 hashes of packages in PR match those in build log and those of packages on https://deb.torproject.org/torproject.org/
- [ ] All 0.4.4.* Tor packages have been removed from `core/`

