### PR TITLE
Adds SecureDrop core 1.8.2-rc1 packages 

### DIFF
--- a/core/focal/securedrop-app-code_1.8.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.2~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d45f969ab88be17413e2fd5622d64367dba4f4fb7f015cd25df1e4903f8e4a89
+size 11014620

--- a/core/focal/securedrop-config-0.1.4+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0bb0d8be4a92051934be4ea14a06dae34b8d455d5a50ec68374f6ad86860b47
+size 3064

--- a/core/focal/securedrop-keyring-0.1.4+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee3e043e4faa3ecca61bf272472caf7e4641d8aa2ca12dda3e6c2511a6ae0f68
+size 5932

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81bff0c210bead3cc83d1d090ced3c24ecec3392817c9e66001141d83fd69576
+size 4664

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ca4c8a3efb26bff868dcd4f2a0ec803a9f1837257f9092dd16c9a90b7d69322
+size 8508


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/9ce5dc5d705bb66e41162021b3c0021b42412432
 

