### PR TITLE
Added packages for SecureDrop 1.8.2-rc2

### DIFF
--- a/core/focal/securedrop-app-code_1.8.2~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.2~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1196e460ab8d6558404c63dce080fc8ec59b7a070587e40cd0e11f0098f95912
+size 11013028

--- a/core/focal/securedrop-config-0.1.4+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.2~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f78b82456761418960c469d675aec7a02c5b1d2a5d974ab669da248e15b66f37
+size 3064

--- a/core/focal/securedrop-keyring-0.1.5+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+1.8.2~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ac73a88dc1c5365d11f88826af0fefb9ad8df3a0108062e0b1a2a0ef8c9643f
+size 8128

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dbb4cfd92fcc4e2d1933959ea0858e4cd84b65e7e6a43e916f02d05067c3ca9
+size 4668

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:900006bb0be55f58073fe52e2a6e2d35fea035d58844b6efdbdb33aa8150006b
+size 8512


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/99a064637792b95f76c7e06677753eeaf874f8ee).
- [ ] Changes are focal-only.

