### PR TITLE
Adds SecureDrop 1.8.2-rc3 packages

### DIFF
--- a/core/focal/securedrop-app-code_1.8.2~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.2~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a94fe5bbeae6ca9c407b88f46301b291b5a26edbf1bfe95cd14728be1c8e02ce
+size 11017928

--- a/core/focal/securedrop-config-0.1.4+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.2~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:413cc8fcb3d61ca764939d6aeb00bfe70bdee0452c9631f79e03c406a4bbea10
+size 3060

--- a/core/focal/securedrop-keyring-0.1.5+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+1.8.2~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00a340362a451feda68e62ce56ccc69bb290234ab66827c183edb3da7ca9562b
+size 8128

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4bbe3ec5fa25eff4b358eab4322238b46bfdccfd01433951f5c9090828ebe8d
+size 4668

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4acbc8af90697824c9d183f4193931568b5724a25726c7d860d431b215909d85
+size 8548


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/4f118e4661835cbfef2bbf33c6318d0949acf5b8).
- [x] packages are focal-only

