### PR TITLE
Adds securedrop-keyring 0.1.5

### DIFF
--- a/workstation/buster/securedrop-keyring_0.1.5+buster_all.deb
+++ b/workstation/buster/securedrop-keyring_0.1.5+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccb9a18c2ad8ecf757995ce16973a58a470f1845cc985717de263446a89e98ad
+size 9196


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist

- [ ] Cross-link to changes made in [securedrop-debian-packaging #250](https://github.com/freedomofpress/securedrop-debian-packaging/pull/250).
- [ ] Build logs [have been committed](https://github.com/freedomofpress/build-logs/commit/bc952e1221f77106d11f0b917ff69e7879787304).

