### PR TITLE
Added Tor 0.4.5.8 packages

### DIFF
--- a/core/focal/tor-geoipdb_0.4.5.6-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.6-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6b374634fcafac2c92b932393cadcaa1daa479eacf98212dc18cde786087a11
-size 997760

--- a/core/focal/tor-geoipdb_0.4.5.8-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.8-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb4138e920e13276211dfc98fde721c1a2f11623f406e2476e18697ea3e17186
+size 860708

--- a/core/focal/tor_0.4.5.6-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.6-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:034b71c8e66284bcbe7f684b4054222b404a151fcf8c335eb9edfdcf783d13aa
-size 1486544

--- a/core/focal/tor_0.4.5.8-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.8-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e40da43d3ea640b46a07d50eb370bab38e2d42e7a07b505300b44170490f8632
+size 1487576


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist 
- [ ] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/6a35b13463ea631ad11a834e9c83f062702f664e
- [ ] SHA256 hashes of packages in PR match those in build log and those of packages on https://deb.torproject.org/torproject.org/
- [ ] Older Tor versions (< 0.4.5.7) have been removed

