### PR TITLE
Adds packages for SecureDrop 2.0.0-rc1

### DIFF
--- a/core/focal/securedrop-app-code_2.0.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c2b514629399376914fb9e782874339abc99b362da3a5200b1903915914b35b
+size 12775692

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2538d674645a38a70e0b33edaf0ba34555d2928926bce9063e4d3415b734c404
+size 3064

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd2e2a5f66e245cd21d268f09a38f3281ef2e89ee6a5f4813149c711073fca86
+size 8124

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a53bf727618bcb4fa422d99f01d2b0e0ec92e543cb3117fb30b7ae70d885dc2c
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:135a095103195613b19cb6b7f5c089e33edc09c18a190af1499fd3bdc76c6f0e
+size 8544


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build logs have been committed at https://github.com/freedomofpress/build-logs/commit/775c6aa73bc1e62df2364a93f640e46f030dcf61
- [ ] packages are focal-only
- [ ] checksums in build logs match checksums of the packages in the PR.

