### PR TITLE
Adds packages for SecureDrop 2.0.0-rc2

### DIFF
--- a/core/focal/securedrop-app-code_2.0.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40adaefd5de40b24cc9f6bd39d3890233c8b7e1e5bd5304b3b0b4380e2ff1754
+size 12774716

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f436a8abfcefe697f186884a0b3b3800a143e304f089e3dbc56c365a6a64720e
+size 3076

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4717cfc367029f4a51ee68ec29c3cd405f8d44e4c94f746e9244294aec776198
+size 8124

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ce896e35232d6fcb32b27481a2c373da85cf93422553efba3b9db00ed6ad418
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:159b0a089a079ace81532867ebfda29d09d07490ccd694044b4487f42f53dc05
+size 8544


### PR DESCRIPTION
## Status

Ready for review
## Description of changes

## Checklist
- [ ] Build logs have been committed at https://github.com/freedomofpress/build-logs/commit/fb3dadb2d55b542d6ccef6e12bd3897c5f386522
- [ ] packages are focal-only
- [ ] checksums in build logs match checksums of the packages in the PR.
