### PR TITLE
SecureDrop 2.0.0-rc4

### DIFF
--- a/core/focal/securedrop-app-code_2.0.0~rc4+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc4+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9cffa42f053693078f4612317bde6963992cc01ec75b97b3fb050c96ec175d1
+size 12774512

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee963d8c1b45c4ad378cc1aaec31a55a647f4aa17ac72800de52a4289882df4a
+size 3064

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1df4587e2002dc0d7383924826958bc28f8f16c1ab6b37d437107b077f2a14a8
+size 8124

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:260435c2a095780ae1e80c2a4c907690c0cc976d0752967b5e32423ea70fec99
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f60e89206cecd43210ee2b1bc0733715e7aed383916718afec3962e6eb10d330
+size 8544


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of changes

## Checklist

- [ ] Build logs have been committed at https://github.com/freedomofpress/build-logs/commit/92cdcdb21723d0f3d203e4af9e61920989a85be5
- [ ] packages are focal-only
- [ ] checksums in build logs match checksums of the packages in the PR.
