### PR TITLE
added 2.0.1-rc1 debs 

### DIFF
--- a/core/focal/securedrop-app-code_1.8.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7455257e1e6ceaafa183da8cd001bb7413b942ad2655601b656a571b2b8c0572
-size 10982064

--- a/core/focal/securedrop-app-code_1.8.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc2+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a10a9653a2e88fb182bfbf474d2677e989da06a6c1eaa97acfea48d00e1fb9c0
-size 10983688

--- a/core/focal/securedrop-app-code_1.8.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc3+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98b74a08c5b4978d7a4b6ce2929beccf9a2ea82f8b3f073feb7cf283af21dbb8
-size 10984360

--- a/core/focal/securedrop-app-code_1.8.0~rc4+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc4+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d824211db8bb0e2af7006c3b5e25cf37c067d45297c96d7fad9f034e62732b97
-size 10984808

--- a/core/focal/securedrop-app-code_1.8.0~rc5+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.0~rc5+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f79187a78a101cece123f814db0783deb5e2495f65801f8f9cff821edbc8fa04
-size 10987640

--- a/core/focal/securedrop-app-code_1.8.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.1~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5263bc39cbdfdaace1dd5cce488fd17fe3609d86287093d99243bcfb78132a10
-size 11013156

--- a/core/focal/securedrop-app-code_2.0.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.1~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:732eb7d3831cd67e0b54a4c479030681d600ee612c9da612b3c961e963057b00
+size 12783148

--- a/core/focal/securedrop-config-0.1.3+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.3+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f2609ec4a1eab1579a8da1c5ae6684505e0a45b16b9da56ce8b7021d53f5d02
-size 2804

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2deabe337cd49dc449933fedf5cad48279d92505af57ec0cbf0a3423121cb63
-size 2956

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c685559a5254637209c54a8aff92a96fb960032ae9bb2a0b0e4db5dd96043305
-size 2960

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c4b1217d383e987f6636ebb8f1ef1b7c681afa729a7ab7ede91f03d6616c41c
-size 3056

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c8bed75686e5ceebff31600bb39791e1fccf9804d6821e7940416dae6318ae3
-size 3064

--- a/core/focal/securedrop-config-0.1.4+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d0895f396f51eb2fbf3bf5268f20281d6e88b29253596c0c32ea34613c45027
-size 3064

--- a/core/focal/securedrop-config-0.1.4+1.8.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6875388f6cb63f56367c10a2eb971178ebd55d503e06c1c078ef8f7d0afeba0e
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a4b1ee63285957c33a24cbf411985738f68a6bfd49499f60d2238ecb3a9de90
+size 3064

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55a58cc24c106a72d2b3e88bb4e0f6ebff961a0794460f0c8bd29e29700e2db4
-size 5928

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:866a961833903d8daed558a87f2968bc94026c6dd48342e28259b2dc6e0c6078
-size 5928

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:255e8b9ca77c27d52412fd90422adf1f623952da10d27aa00a0e93afbba89e8b
-size 5928

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9121dae4803fa99321b023908ae77318b756aa53883b96c77ab491670c5524e3
-size 5924

--- a/core/focal/securedrop-keyring-0.1.4+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5bc0823396b56b55bf7c9d5b2847d01ca6f7cbf0f67961880ea7cc76601be7ba
-size 5924

--- a/core/focal/securedrop-keyring-0.1.4+1.8.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecc6b2c8d4dc432e79f8ec161923bf268eae27d1087ce362e20a6ed83acd842b
-size 5932

--- a/core/focal/securedrop-keyring-0.1.5+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb7b7941d266ab3c14d692128c8f3fda64bf892a35b1cc0cbb350cd868df90f
+size 8120

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:808535e24845970cc32c7e32f3f118de313eaae03954df9cfd865deb68c84781
-size 4668

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fd38b59cbc21a7e4f2b26ad09446e9005d86f0ddabe8ce5c53cafc1a88841ee
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25ac29b2fda9975b139b9b670af695f2345dba381ecc523feb177a7ff622128a
-size 4668

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:417e1e36bade19e08b7030bff33e465e8c8f7f878b3d255c26fe8092614285dd
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c807e6aa0fabcece8f6ae4ea3281e47838e3bb7de43723b611ea795603bd2699
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e02123ff23c95c15b54642516d586f47758deec92f0421add1b48ae956adb2b
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:768b68843f5d526e9ea8208b1e96a6c596d4f9f22017b53a99e2a49415f7255b
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:089fe8e2fba418e7983327e0ce76628edc241d3bc12e7a2722fb12885b4e14c5
-size 7924

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df7a813ce5e1265520de6a0bc9417eb3fc83ffc6ee65a552ebfe78616bdea592
-size 7920

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47425d632e6a6852a4328d9e62088ee7aaa626d4ac1ab397856e92e2820105e7
-size 7920

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cebf25282b01142bf45d49bb1c29ed0f66061fd4c101639a72ebfae86bda67ab
-size 7916

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd091799abd87fbe1dc2b0250c8ca539aa43782273fcd3f0869cab785041a2e4
-size 7916

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:559815011751241c29e89627935663757077e12a570ac97097e0bd8de1c43cda
-size 8016

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:343a7ff4be00547ca2277fce6470b8529dedfe8351a158b8616210464828d40b
+size 8536


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

Adds 2.0.1-rc1 debs, cleans up old 1.8.0 and 1.8.1 release candidates. 

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
- [ ] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/b3d59394285b19785bb269a3fbdf6bd5e21ad3aa
- [ ] sha256 hashes in build log match those of the added packages.
