### PR TITLE
Workstation kernel 4.14.240

### DIFF
--- a/workstation/buster/linux-headers-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-headers-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eade17108246475a8711cec5882e20701878d04bfa76e0de95e61a83cdc29c68
+size 24627992

--- a/workstation/buster/linux-image-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-image-4.14.240-grsec-workstation_4.14.240-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b299e5716820775f7f3a15bd78ceadf741a5202cfe5851776cf5c175f03b6ba7
+size 35319824

--- a/workstation/buster/securedrop-workstation-grsec_4.14.240+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.240+buster_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1adf6394605d4317971dfd74086b60bff65683ec212e524bb90e5c35e288ed99
+size 3688


### PR DESCRIPTION


## Status

Ready for review 

## Description of changes
Includes metapackage [0] and kernel images.

[0] https://github.com/freedomofpress/securedrop-debian-packaging/pull/255

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging). https://github.com/freedomofpress/securedrop-debian-packaging/pull/255
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs):
  - Metapackage: https://github.com/freedomofpress/build-logs/commit/668a48daac0a6100058fab9fbcf7f460d4ab6ab7
  - Kernel: https://github.com/freedomofpress/build-logs/commit/1fda41b2104fe4a3fde2edc4be873c6806be7fda
- [ ] Source tarballs have been uploaded to s3 bucket

## Testing

I haven't actually tested these changes yet, but I'm comfortable doing so post-merge to apt-test, and will follow up with further changes only if required.

