### PR TITLE
Rebuilds metapackage for workstation kernel

### DIFF
--- a/workstation/buster/securedrop-workstation-grsec_4.14.240+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.240+buster_amd64.deb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1adf6394605d4317971dfd74086b60bff65683ec212e524bb90e5c35e288ed99
-size 3688
+oid sha256:277805b62d58be7c42d7f485e2d05e7e3f0291ceafe948570a67c2451e8bdb12
+size 3684


### PR DESCRIPTION


## Status

Ready for review

## Description of changes

Follow-up to #116 

Omitted the version string bump in the control file, so the new packages
weren't pulled in, but postinst tried to operate on the dkms modules,
resulting in an install failure.

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/256
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs). https://github.com/freedomofpress/build-logs/commit/09bdb7c6de498b4c369ab75d92a4e0c79dfe8e17

