### PR TITLE
Workstation kernel 4.14.241

### DIFF
--- a/workstation/buster/linux-headers-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-headers-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1f43333e75e8ac46aa319157940ea7982ee4f3d0b9fda711d85d77d5b77b2bf
+size 23468540

--- a/workstation/buster/linux-image-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
+++ b/workstation/buster/linux-image-4.14.241-grsec-workstation_4.14.241-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:951348d9e237c1a60fa54c130c23ecfcf2691acd74d30fbbeeecd00c83cf5347
+size 57108864

--- a/workstation/buster/securedrop-workstation-grsec_4.14.241+buster_amd64.deb
+++ b/workstation/buster/securedrop-workstation-grsec_4.14.241+buster_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52a7a4a0ddd7c3385d03376e7d4876d7e19eede162c131426553e7b19dc8b58c
+size 3688


### PR DESCRIPTION

## Status

Ready for review  

## Description of changes


## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging) - https://github.com/freedomofpress/securedrop-debian-packaging/pull/259
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs) - https://github.com/freedomofpress/build-logs/commit/d97bc30c9362ff1f5120da1658848ec22c924c18

