### PR TITLE
Added Tor 0.4.5.10 packages

### DIFF
--- a/core/focal/tor-geoipdb_0.4.5.10-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.10-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73bb1771b652949d56cbd84082d1008d46ea4e333dcacbd5a38bf1d0299c1b06
+size 893124

--- a/core/focal/tor-geoipdb_0.4.5.7-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.7-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bafdbf7e088ac95ef15fde48a6a0de5e1650bdbbc11c6468acc6caf82611bd6d
-size 867776

--- a/core/focal/tor_0.4.5.10-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.10-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2899925514f97155fd7cafecd7be7a4ca5b0f616104632e878bbde18951fc1a
+size 1487840

--- a/core/focal/tor_0.4.5.7-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.7-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd96342207997f805100bc8a429aeecf143f0f7d91b544fc962d438a5cd19184
-size 1486912


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed: https://github.com/freedomofpress/build-logs/commit/79d27a01179d0005ea0d14b5e324912aa6a651af
- [x] packages match those on https://deb.torproject.org/torproject.org/
