### PR TITLE
Remove unused repo channels

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -1,12 +1,4 @@
 Origin: SecureDrop
-Codename: xenial
-Components: main
-Architectures: amd64
-ValidFor: 6m
-Description: SecureDrop server packages (xenial)
-SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
-
-Origin: SecureDrop
 Codename: focal
 Components: main
 Architectures: amd64
@@ -15,16 +7,8 @@ Description: SecureDrop server packages (focal)
 SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
 
 Origin: SecureDrop
-Codename: stretch
-Components: main
-Architectures: amd64
-ValidFor: 6m
-Description: SecureDrop Workstation packages (stretch)
-SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
-
-Origin: SecureDrop
 Codename: buster
-Components: main template-consolidation
+Components: main
 Architectures: amd64
 ValidFor: 6m
 Description: SecureDrop Workstation packages (buster)


### PR DESCRIPTION


## Status

Ready for review 

## Description of changes

Removes Xenial, Stretch, and a no-longer used "template-consolidation"
channel that was used for testing on Buster. Closes #115.

## Checklist
Visual review is fine. Probably worth checking the day after merge that nightlies are still flowing.

