### PR TITLE
Added Tor 0.4.6.8 packages, removed 0.4.5.8 packages

### DIFF
--- a/core/focal/tor-geoipdb_0.4.5.8-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.8-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb4138e920e13276211dfc98fde721c1a2f11623f406e2476e18697ea3e17186
-size 860708

--- a/core/focal/tor-geoipdb_0.4.6.8-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.6.8-1~focal+1_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3de43d58a2a7e091bbcc31af62abf2cd390f8edebb4666bf37546a9b73a10ce
+size 890796

--- a/core/focal/tor_0.4.5.8-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.8-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e40da43d3ea640b46a07d50eb370bab38e2d42e7a07b505300b44170490f8632
-size 1487576

--- a/core/focal/tor_0.4.6.8-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.6.8-1~focal+1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d2b81cd9be3a6401762237114076c702d7443808b73c82ef91325dda7a833d9
+size 1445692


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Build logs have been committed: https://github.com/freedomofpress/build-logs/commit/2714837450a85d94a3d7d12715a21806ce4072c9
- [ ] packages match those on https://deb.torproject.org/torproject.org/