### PR TITLE
securedrop-client 0.6.0-rc1

### DIFF
--- a/workstation/buster/securedrop-client_0.6.0-rc1+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:046bf288af4be2e4299610e0ec6cf851adab124228d5f8da4706ef1f7a28797a
+size 8332148


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/285
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/45a669f3630ec733bc8c16885db4e9eb560d8249
- [ ] Make sure tag matches https://github.com/freedomofpress/securedrop-client/releases/tag/0.6.0-rc1

