### PR TITLE
Remove client 0.6.0 nightlies

### DIFF
--- a/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220127-060610+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220127-060610+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01d78eb891ecd5daac5adca71915688fbe7e0c705ef261286f31f52d7a038e38
-size 8094960

--- a/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220128-060543+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220128-060543+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa1e297fb049e19d9f4a26ec54bda665b72f6d54e3af16dda3ac96223a6c9544
-size 8094316

--- a/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220129-060601+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220129-060601+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2714ad877ef77b91d9c2cc43be8dbbaf5b2a891aaba5926e7f37085bfe09b8bf
-size 8094416

--- a/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220130-060550+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220130-060550+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2bfcae5fd4a4179bc018ce0f2318c18f35343e71c6509c125f3b5d1ab86fee8
-size 8093900

--- a/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220131-060613+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc1-dev-20220131-060613+buster_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a14f1936302f9b50ff766084feafcc8792feac7a1eaa89ee249599b649640f87
-size 8333988


### PR DESCRIPTION

## Status

Ready for review 
## Description of changes

We forgot to pause the nightlies last week, prior to preparing an rc1
package, so the nightly packages are winning on dpkg version compare:

```
  dpkg --compare-versions 0.6.0-rc1+buster gt 0.6.0-rc1-dev-20220127-060610+buster
  echo $?
  1
```

Removing them to resolve the conflict, and ensure only 0.6.0-rc1 is
served from apt-test.


## Checklist

See testing details below. Our "just pull from git" logic on apt-test isn't smart enough to handle package removals intelligently, so old packages can still appear in the HTML webview—but reprepro only honors the most recent available version, and the repo metadata was correct, so 0.6.0-rc1 was being offered, as expected.
