### PR TITLE
securedrop-client 0.6.0-rc2

### DIFF
--- a/workstation/buster/securedrop-client_0.6.0-rc2+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc2+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f48a00c3c329c6c9d2ea18b58a41be93d7b146381e7ca9d42db46dd8322af35
+size 8373600


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/288
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/bccbe755df35bdf084794c8dbc4cc5e268f76d08

