### PR TITLE
Add securedrop-client 0.6.0-rc3

### DIFF
--- a/workstation/buster/securedrop-client_0.6.0-rc3+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc3+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dbf235a9c9374182c24f0db736eabfae6a20d3934ea94e638d21453df0b71d1
+size 8399280


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/290
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/d56ff2841e827078240eafffa4c01ab27b1ee765
- [ ] Checksum of package matches what's shown in build logs

