### PR TITLE
Add SecureDrop 2.2.0-rc2 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.2.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.2.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cb3d76f10221b7196f3a5e5d29e9be48b80acf2954c898b39c0d41acabb3872
+size 13659012

--- a/core/focal/securedrop-config-0.1.4+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.2.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d9ad6de7740b1d46fad952577dc9e2db0a54815c4d09c8f615734e6aba39191
+size 3064

--- a/core/focal/securedrop-keyring-0.1.5+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.2.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bfb5b773cf321b15dc318e78807554c60c76fb9b5dbc7453d5d1314c220daf8
+size 3748

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10f6186fffe7331c0a36eb5faea79884e6d65937795c230bb03be184d89e6344
+size 4664

--- a/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb1dde3012d7d729b083f0711b72b88f684d5fcb9cf5af3b140b1c5c463227d0
+size 8640


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Make sure tag is correct: https://github.com/freedomofpress/securedrop/releases/tag/2.2.0-rc2
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/684f3e76930582f281fdecc8da78cc26934515cc
- [x] Checksums in build logs match those for packages submitted here
