### PR TITLE
Add securedrop-client 0.6.0-rc4

### DIFF
--- a/workstation/buster/securedrop-client_0.6.0-rc4+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.6.0-rc4+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1efd5f8fe8951d07b2d48537b40b6da804b057f8d0b7ecf7d5628eb764a4f8cf
+size 8410300


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/292
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/0945ed1b38afc94df9ebfc8da74eac672a540c22
- [ ] Checksum of package matches that in build log

