### PR TITLE
Add 2.2.1-rc1 and securedrop-grsec-5.15.26 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.2.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.2.1~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9a52a08e99d8239902363b3623ae68e8b1ff9a270a2c87be9cea1fd69a98781
+size 13667612

--- a/core/focal/securedrop-config-0.1.4+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.2.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7299e54a32cbc08064b83c23bef9d80405caf60725607d7217196135035a7b1
+size 3064

--- a/core/focal/securedrop-grsec-5.15.26+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.15.26+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11453ef26aa75de224c09b4434e53f5f2da966462bc601195fff0868cfcc1808
+size 3044

--- a/core/focal/securedrop-keyring-0.1.5+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.2.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe170b1d37cad4dae6a653cf2d1d7f6bb7fab41662d57d77fea9b6407f62116
+size 3752

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.2.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c855429aaa46ec4cf346fb8ceb9807f82b82a770cee3cddf73652b1110047a6c
+size 4664

--- a/core/focal/securedrop-ossec-server-3.6.0+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.2.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aac35208babe1cf9a40e1d6deab6f26c57f4d21dff4838d22eeb8fea5f4809e2
+size 8644


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of changes

## Checklist
- [x] Build logs have been committed in https://github.com/freedomofpress/build-logs/commit/27a4e3b363a5d87dd0939a6504c3d6b1ca8c3473
- [x] build was from correct tag (`2.2.1-rc1`)
- [x] hashes of included packages match those in the build logs

