### PR TITLE
Add securedrop 2.3.0 rc1

### DIFF
--- a/core/focal/linux-headers-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a724f42e8093fc33b252a559304c327f81ec5f67f4c592a0cabb0e1c43687d2
-size 24125572

--- a/core/focal/linux-image-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.4.97-grsec-securedrop_5.4.97-grsec-securedrop-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c00a4de094188c56c53e616ee3abb281d4b58207e6d7b1ef8249c21a51d2c34
-size 53224848

--- a/core/focal/securedrop-app-code_1.8.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.2~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d45f969ab88be17413e2fd5622d64367dba4f4fb7f015cd25df1e4903f8e4a89
-size 11014620

--- a/core/focal/securedrop-app-code_1.8.2~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.2~rc2+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1196e460ab8d6558404c63dce080fc8ec59b7a070587e40cd0e11f0098f95912
-size 11013028

--- a/core/focal/securedrop-app-code_1.8.2~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_1.8.2~rc3+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a94fe5bbeae6ca9c407b88f46301b291b5a26edbf1bfe95cd14728be1c8e02ce
-size 11017928

--- a/core/focal/securedrop-app-code_2.0.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c2b514629399376914fb9e782874339abc99b362da3a5200b1903915914b35b
-size 12775692

--- a/core/focal/securedrop-app-code_2.0.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc2+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40adaefd5de40b24cc9f6bd39d3890233c8b7e1e5bd5304b3b0b4380e2ff1754
-size 12774716

--- a/core/focal/securedrop-app-code_2.0.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc3+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea0080f34ab1c6eedc778510348d4e86c373499c89978fd43bae4ecdc5cf848d
-size 12773452

--- a/core/focal/securedrop-app-code_2.0.0~rc4+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc4+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9cffa42f053693078f4612317bde6963992cc01ec75b97b3fb050c96ec175d1
-size 12774512

--- a/core/focal/securedrop-app-code_2.0.0~rc5+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.0~rc5+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e9db964e271d1e2aa22d5a32b5e43c455ca9928436e567337c371500bbfea44
-size 12778172

--- a/core/focal/securedrop-app-code_2.0.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.1~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:732eb7d3831cd67e0b54a4c479030681d600ee612c9da612b3c961e963057b00
-size 12783148

--- a/core/focal/securedrop-app-code_2.0.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.0.2~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dcd1a699538352d7864909547145173145fba623bee5838aca48605173492db8
-size 12778720

--- a/core/focal/securedrop-app-code_2.3.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.3.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a2473ae2305195463efc4442a389067792a2037d271dc0076048018bee5ad13
+size 13668568

--- a/core/focal/securedrop-config-0.1.4+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0bb0d8be4a92051934be4ea14a06dae34b8d455d5a50ec68374f6ad86860b47
-size 3064

--- a/core/focal/securedrop-config-0.1.4+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.2~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f78b82456761418960c469d675aec7a02c5b1d2a5d974ab669da248e15b66f37
-size 3064

--- a/core/focal/securedrop-config-0.1.4+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+1.8.2~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:413cc8fcb3d61ca764939d6aeb00bfe70bdee0452c9631f79e03c406a4bbea10
-size 3060

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2538d674645a38a70e0b33edaf0ba34555d2928926bce9063e4d3415b734c404
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f436a8abfcefe697f186884a0b3b3800a143e304f089e3dbc56c365a6a64720e
-size 3076

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e61ba99ab9f3df35bea274ce207b71391e74a602a79e8c5a09a10b0d9a612696
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee963d8c1b45c4ad378cc1aaec31a55a647f4aa17ac72800de52a4289882df4a
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.0.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40d922e286e679c191f8db281198733404aa272565a93d0e7961a1a9904b587c
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a4b1ee63285957c33a24cbf411985738f68a6bfd49499f60d2238ecb3a9de90
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.0.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.0.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:566db0b983ee177dec8ea3148043b206081295eb8396a004df9685c8febdb9a9
-size 3068

--- a/core/focal/securedrop-config-0.1.4+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.3.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:486ad9989b10f4bf144523c9e4cbc918be3f1c6f437055217d65933ec14ab4cc
+size 3064

--- a/core/focal/securedrop-grsec-4.14.188+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-4.14.188+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3971d0e55035dc220102462d92c9b787d7e11740f0b9d9b98a42d4e648e1f959
-size 3016

--- a/core/focal/securedrop-grsec-5.4.88+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.4.88+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad4cf81a5204f9b2fe42f8c4ef421a9a8b1dd3e854d0cc7629034f8a4c6136f5
-size 2960

--- a/core/focal/securedrop-grsec-5.4.97+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.4.97+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ffeafc956deb575a4316a0fa90752a260b6e1fc050c8ccf71bf63348bff4248
-size 3000

--- a/core/focal/securedrop-keyring-0.1.4+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.4+1.8.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee3e043e4faa3ecca61bf272472caf7e4641d8aa2ca12dda3e6c2511a6ae0f68
-size 5932

--- a/core/focal/securedrop-keyring-0.1.5+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+1.8.2~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ac73a88dc1c5365d11f88826af0fefb9ad8df3a0108062e0b1a2a0ef8c9643f
-size 8128

--- a/core/focal/securedrop-keyring-0.1.5+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+1.8.2~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:00a340362a451feda68e62ce56ccc69bb290234ab66827c183edb3da7ca9562b
-size 8128

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd2e2a5f66e245cd21d268f09a38f3281ef2e89ee6a5f4813149c711073fca86
-size 8124

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4717cfc367029f4a51ee68ec29c3cd405f8d44e4c94f746e9244294aec776198
-size 8124

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ac92b47d3526a49b20b3d4bad29241a2a230d977ff473cb821d6d8d2744d2da
-size 8120

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1df4587e2002dc0d7383924826958bc28f8f16c1ab6b37d437107b077f2a14a8
-size 8124

--- a/core/focal/securedrop-keyring-0.1.5+2.0.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6228987108186abc2ceff843733a32e74517cc92e45ec9f932e95e78635d2324
-size 8124

--- a/core/focal/securedrop-keyring-0.1.5+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cb7b7941d266ab3c14d692128c8f3fda64bf892a35b1cc0cbb350cd868df90f
-size 8120

--- a/core/focal/securedrop-keyring-0.1.5+2.0.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.0.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6111c3cc0899d1e9235716d6b75b1f7d2cb3bbaf95947677609b24937392bcaf
-size 8120

--- a/core/focal/securedrop-keyring-0.1.5+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.3.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c746831843bb66cf8bab27657ea755f15b4cce02358d92d36cd3bc132bc3302e
+size 3748

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81bff0c210bead3cc83d1d090ced3c24ecec3392817c9e66001141d83fd69576
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dbb4cfd92fcc4e2d1933959ea0858e4cd84b65e7e6a43e916f02d05067c3ca9
-size 4668

--- a/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+1.8.2~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4bbe3ec5fa25eff4b358eab4322238b46bfdccfd01433951f5c9090828ebe8d
-size 4668

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a53bf727618bcb4fa422d99f01d2b0e0ec92e543cb3117fb30b7ae70d885dc2c
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ce896e35232d6fcb32b27481a2c373da85cf93422553efba3b9db00ed6ad418
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a4735b09db2fcc7a1138711795f3f5b471f8f4a2b5d0a697e0b76588c71f835
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:260435c2a095780ae1e80c2a4c907690c0cc976d0752967b5e32423ea70fec99
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53d986d5e0b8f49b634a465636b4b94535d51673d8a677600de886fe1634afe2
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:768b68843f5d526e9ea8208b1e96a6c596d4f9f22017b53a99e2a49415f7255b
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.0.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.0.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a426e4f78482be2fe099ccf6ef7bb67a4734fd3d5a2a59a1fcaa47e2d890f2f
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.3.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf00f17fc2bcdd65d1488b949e10c92523193ea3f9acbd41f3878f59a4244bc1
+size 4664

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ca4c8a3efb26bff868dcd4f2a0ec803a9f1837257f9092dd16c9a90b7d69322
-size 8508

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:900006bb0be55f58073fe52e2a6e2d35fea035d58844b6efdbdb33aa8150006b
-size 8512

--- a/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+1.8.2~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4acbc8af90697824c9d183f4193931568b5724a25726c7d860d431b215909d85
-size 8548

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:135a095103195613b19cb6b7f5c089e33edc09c18a190af1499fd3bdc76c6f0e
-size 8544

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:159b0a089a079ace81532867ebfda29d09d07490ccd694044b4487f42f53dc05
-size 8544

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b59bbb900c2588fbf3a835f44745cc58ac61fb6bf600d594e91fe37273d77a7
-size 8540

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc4+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f60e89206cecd43210ee2b1bc0733715e7aed383916718afec3962e6eb10d330
-size 8544

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc5+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.0~rc5+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55fb03643a33d29f8525b03dec136c91117e2f9f98d54122bd7bda6b42bc3037
-size 8540

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:343a7ff4be00547ca2277fce6470b8529dedfe8351a158b8616210464828d40b
-size 8536

--- a/core/focal/securedrop-ossec-server-3.6.0+2.0.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.0.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:340067fd4287efd91394e71f9b90d04cc2c9f6c69f3b0e17bc29978b1b92cd91
-size 8548

--- a/core/focal/securedrop-ossec-server-3.6.0+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.3.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2a2dff1efab83bbe7cbd0dc28fcb328ee87e91b8ca8a3412f8bac41be7c0fbf
+size 8640


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist 
- [ ] Build log has been committed to https://github.com/freedomofpress/build-logs/commit/5ea9dc899eec00c0f9502c1a244e1191a369bad6
- [ ] Correct tag was verified
- [ ] Checksums here match what's in the build log
