### PR TITLE
Add securedrop-client-0.7.0-rc1

### DIFF
--- a/workstation/buster/securedrop-client_0.7.0-rc1+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.7.0-rc1+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f9b5a6bcc45520c566159d3664df503695100a6fb75e269362f4d64efcf2435
+size 8475280


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes
SecureDrop Client 0.7.0-rc1

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging):  https://github.com/freedomofpress/securedrop-debian-packaging/pull/300
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs):  https://github.com/freedomofpress/build-logs/pull/8 (It's a PR not a commit, which may have been overly cautious on my part)

