### PR TITLE
Add securedrop-client 0.7.0-rc2

### DIFF
--- a/workstation/buster/securedrop-client_0.7.0-rc2+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.7.0-rc2+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a1108497d371f7511836e4b84f155d93e7440ee24a237fa0968702117f4920c
+size 8476484


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Towards https://github.com/freedomofpress/securedrop-client/issues/1465

## Checklist
- [x] Cross-link to https://github.com/freedomofpress/securedrop-debian-packaging/pull/303
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/bb9834def6568f0ddeb7b034f96c98ebede4a988
   - [x] Correct securedrop-client tag was verified and checked out
   - [ ] Checksum matches deb being added here

