### PR TITLE
Add securedrop-client 0.7.0-rc3

### DIFF
--- a/workstation/buster/securedrop-client_0.7.0-rc3+buster_all.deb
+++ b/workstation/buster/securedrop-client_0.7.0-rc3+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b882e25cccd464e7e0dc3e26f0ad34fc19409028a777e38d68f7aae8b2a5c134
+size 8476772


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Towards https://github.com/freedomofpress/securedrop-client/issues/1465

## Checklist
- Cross-link to https://github.com/freedomofpress/securedrop-debian-packaging/pull/303
- Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/d2b03e0e74ed8b2a510600ce0e0a7b9703b0b25a
   - [x] Correct securedrop-client tag was verified and checked out
   - [x] Checksum matches deb being added here

