### PR TITLE
Update workstation packages to their recent stable versions

### DIFF
--- a/workstation/buster/securedrop-export_0.2.6+buster_all.deb
+++ b/workstation/buster/securedrop-export_0.2.6+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:275d7d9b0c9fca540a2ad25c22777fbb193d4fee611520f09bac0c524883777e
+size 4597676

--- a/workstation/buster/securedrop-proxy_0.3.1+buster_all.deb
+++ b/workstation/buster/securedrop-proxy_0.3.1+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e2314d3d5f1a74d48a19d7673fdb816188cbd6901a3d0ded28da1136243a061
+size 4877348

--- a/workstation/buster/securedrop-workstation-svs-disp_0.2.2+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-svs-disp_0.2.2+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ba8ed23f94ad742ccdc1b9e56c9050f5667b84a8cfcf74d98ace2c9f2d22df
+size 3576


### PR DESCRIPTION
## Description of changes

Copied the deb files from `securedrop-debian-packages-lfs`.

Fixes #149

## Checklist
- [ ] ~Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).~
- [ ] ~Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).~
- [ ] Hashes for the new deb's match those in `securedrop-debian-packages-lfs`

