### PR TITLE
add securedrop-workstation-config 0.1.7

### DIFF
--- a/workstation/buster/securedrop-workstation-config_0.1.7+buster_all.deb
+++ b/workstation/buster/securedrop-workstation-config_0.1.7+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e664c5e1eade57f59f1556aed05c2e59d1fb1c8533388c69aa2d5aefb84bb0f
+size 5684


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop-debian-packaging/issues/312

Once this PR is merged and on `apt-test`, follow test plan in https://github.com/freedomofpress/securedrop-debian-packaging/issues/312

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging/commit/2dcb936f07773dfe643b1730d717a188728dd79c).
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/c337676976559b809c04b4065279efbfdf6683ae).

