### PR TITLE
added securedrop 2.4.0-rc1 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.4.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.4.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27a25e97042af09a8cea06ac9c5c3a9f04796d30275f616749543b6baa159df8
+size 13593508

--- a/core/focal/securedrop-config-0.1.4+2.4.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.4.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2fb7fef4c4b562a05e318854f64c8f0ad4ea5570f668ab24578919cc825919a
+size 3116

--- a/core/focal/securedrop-keyring-0.1.5+2.4.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.4.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79dc67d22d3c7d67a91d1a2c65465e6e4eb9b385ac4369c333a6414a8cc5d2f6
+size 3748

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.4.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.4.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c670752c43df81d45fb43497fa69cc7e159aa9e5aaaa94b9d407a3766f034ecd
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.4.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.4.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42947c83a04f8fac0db631c91f030f067ff4779b7abf44343a7082d842622cfc
+size 8636


### PR DESCRIPTION
## Status

Ready for review 

## Checklist
- [ ] Build log has been committed to https://github.com/freedomofpress/build-logs/commit/afc1a3d7dfbd57925f07b81192fb2197444b927b
- [ ] Correct tag was verified
- [ ] Checksums here match what's in the build log
