### PR TITLE
add securedrop-keyring 0.1.6 packages for buster and bullseye

### DIFF
--- a/workstation/bullseye/securedrop-keyring_0.1.6+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-keyring_0.1.6+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d34fa9a4561fbef82fbc80371088a7a8414cc534aa40bb446c1943dc08ec6e0
+size 4844

--- a/workstation/buster/securedrop-keyring_0.1.6+buster_all.deb
+++ b/workstation/buster/securedrop-keyring_0.1.6+buster_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f74ba4899a0700c80665de9256baf554cb07f8858c2ec59eefe70af14c7e6c14
+size 4836


### PR DESCRIPTION
## Status

Ready for review

Towards https://github.com/freedomofpress/securedrop-debian-packaging/issues/319

## Checklist
- [x] Changelog added: https://github.com/freedomofpress/securedrop-debian-packaging/commit/1d6f457951de95467b2733b9d8ca19cb360e0914
- [x] Build logs for buster been committed to build-logs repo: https://github.com/freedomofpress/build-logs/commit/914578a672aea33b43ac9cc4e045c692ece0f910#diff-d1aebfdc658308917a118c6b44f4b24f459020fbdb99a3df0d5c2ce5753f4996
- [x] Build logs for bullseye been committed to build-logs repo: https://github.com/freedomofpress/build-logs/commit/914578a672aea33b43ac9cc4e045c692ece0f910#diff-aeacdd346884dbea6dca7460f3ff335af21c18b0fcebe60d1eddf724ddff1bd2

