### PR TITLE
Added securedrop 2.4.0-rc2 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.4.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.4.0~rc2+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6f24ace32dce977f3d6795a3c97839d15c242b6c32e1ad6c375ae829578f5b0
+size 13596024

--- a/core/focal/securedrop-config-0.1.4+2.4.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.4.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d9d9cc2fa2c29b7e419c9e962836e571eb1c48251ef9c630f633fd670a07ae6
+size 3116

--- a/core/focal/securedrop-keyring-0.1.6+2.4.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.6+2.4.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa720a990dd88851c5730f5a52426a3d98691fceba3600db211b409f2d6629a3
+size 3724

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.4.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.4.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9484ed41e9e61db9b454dc2154ae4a89a550c2415d024373454565e94b7e9b93
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.4.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.4.0~rc2+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:153ca6fd0dca505669c5977e9da690c95777bd57066481230a9ae05fd3eae2f5
+size 8640


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/c34b17f7fbd3e4d3e6313799a32647d82401c65f).
- [x] correct tag was used in build logs
- [x] hashes in build logs match those of the files in the PR.

