### PR TITLE
add packages for workstation kernel 5.15.41

### DIFF
--- a/workstation/bullseye/linux-headers-5.15.41-grsec-workstation_5.15.41-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.41-grsec-workstation_5.15.41-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0e2a092baf355a0dee0ba55c2429e9a0025a5d45931663cb0c4efeae1bf19ab
+size 23386868

--- a/workstation/bullseye/linux-image-5.15.41-grsec-workstation_5.15.41-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.41-grsec-workstation_5.15.41-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b88a181e17dcc5e0a8cd0034683f5cc7b6a18f73d2ee2be2edf68871eaa086de
+size 46397604

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.41-1~bullseye_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.41-1~bullseye_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c69916e8873fad21589227a4e698df990b30d584f6db41b891725aceeafba3
+size 3496


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/326
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/add4b84408159c00abcec8f658def8587e18781e

