### PR TITLE
add securedrop-workstation-config 0.1.7 package for bullseye

### DIFF
--- a/workstation/bullseye/securedrop-workstation-config_0.1.7+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-config_0.1.7+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c80712433637ad9309d711e782577b615ed6cbe7188ad855e35fd88439cb1b4
+size 5260


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Add securedrop-workstation-config 0.1.7 for bullseye.

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/327
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/bfdc2aab8c868c73b2cec310dd244716674c6681

