### PR TITLE
host buster's `xpp` for bullseye

### DIFF
--- a/workstation/bullseye/xpp_1.5-cvs20081009-4_amd64.deb
+++ b/workstation/bullseye/xpp_1.5-cvs20081009-4_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61831b5a7cd869a5ce7fc78f8603bcbbe5af936141ec5346810ad75b0a6ad825
+size 53392


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Works towards freedomofpress/securedrop-debian-packaging#343 by adding buster's last `xpp`, which installs and runs on bullseye. 

## Checklist
- [ ] `xpp_1.5-cvs20081009-4_amd64.deb` verifies against <https://packages.debian.org/buster/amd64/xpp/download>.