### PR TITLE
copy xpp package to nightlies

### DIFF
--- a/workstation/bullseye-nightlies/xpp_1.5-cvs20081009-4_amd64.deb
+++ b/workstation/bullseye-nightlies/xpp_1.5-cvs20081009-4_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61831b5a7cd869a5ce7fc78f8603bcbbe5af936141ec5346810ad75b0a6ad825
+size 53392


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Copied https://apt-test.freedom.press/pool/main/x/xpp/ into nightlies so that we can test on Qubes 4.1 using `make dev`.

## Test Plan
- [x] Verify against packing in `main`
