### PR TITLE
add securedrop-workstation-config 0.2.0 package for bullseye

### DIFF
--- a/workstation/bullseye/securedrop-workstation-config_0.2.0+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-config_0.2.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa184cdeb38b700f140426242cd798d321c0055c6103b55fb663d38989702305
+size 5748


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): 
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/3a332a3ad5a8fdd62da475beca55fbb9fd478b52

