### PR TITLE
Clean up old securedrop-workstation-grsec nightlies

### DIFF
--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-1~bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-1~bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4c69916e8873fad21589227a4e698df990b30d584f6db41b891725aceeafba3
-size 3496

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220616-062342+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220616-062342+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a11299551d59a306a679ae08da5aa7fb359f7788ebd8d0956509439e3149760
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220616-215726+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220616-215726+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ca06c3da7b2908f76c846be609f502d202459ae8c2c4534b77becf60cd17c57
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220617-062414+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220617-062414+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:61f272cb2fb1b9d373a8dbeffc2f37bf7b770b4bd0ec09049fb7c0224e344bd5
-size 3592

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220618-062426+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220618-062426+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8821f2313a76d6abc231d650f4946f04101c487040e1caa745c74937e3d2b3dd
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220619-153700+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220619-153700+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33ec97aac783aebefa98709dbd46634f9820f1091f5bb61432fcd86af4724283
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220620-062411+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220620-062411+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:457de741d3e1702fce0b9cc42d5b05532d51e8fc8998f6427d8697ce748df601
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220621-062335+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220621-062335+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d600410007f4130d60e2c30c9a832bb1c649482ed3e9fc7145c1a5fab998870
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220622-062452+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220622-062452+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2356388957d8fb1786903f99c28a00e565a66efa92c8e7ee907ff24ad97d2d15
-size 3580

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220623-062415+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220623-062415+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9c51aa6916eb486b479d2e89c68eca84f36901cb7e2a3bb64dbc49ceb26d4abe
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220623-174722+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220623-174722+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4fabb522755ac0eb34fcc562e7914b89a32c738e304ed2d43b331cf4ce2ce47
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220623-230321+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220623-230321+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca0fd673592277d456893091f23d6b88948f019e9fee02f994dd60879dc562af
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220624-062427+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220624-062427+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:389d52ca09a9e20347f0b3181b9eba74ac1edee3b2dcd2962b9274d7f3fb757d
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220625-062219+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220625-062219+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6db3ad304f0ab3656faf8e1b71a04ef05f161426f380d7c725e7ba3e8a26438e
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220626-062311+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220626-062311+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:084c25a5e9db6d53afe63f37de774c7ca9f5ff13b24a2252a1a3136b2cc00bbc
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220627-062237+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220627-062237+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fad86410d1dd5f772b507f7ccef39fb4ce98636d48fb04ccbe702671113a0b2a
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220628-062440+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220628-062440+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f55d84e1fda214170455fcac74c4d606d6103c2336aeb15fa617a2d0d11f645a
-size 3588

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220628-153056+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220628-153056+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d98fe65463d08543e3f8c7f1fd9d1fdb867a105c26ab3247325c27e45ff05601
-size 3584

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220629-062426+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220629-062426+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8e9327e1889b9fb3fdb4ff73e5dcf9ab255a072afc6be9d305f3aa7e6534c50
-size 3580

--- a/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220630-062327+bullseye_amd64.deb
+++ b/workstation/bullseye-nightlies/securedrop-workstation-grsec_5.15.41-dev-20220630-062327+bullseye_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fbaa8a59206b0a78e85dc31271210d7f195c61dfba218953c660c75ef4e1a13
-size 3588

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220616-061419+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220616-061419+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69ce81d991d1efdb481f936a9219a0edf2559ddc8031d5f3a49d00b8a1566431
-size 3972

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220616-214738+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220616-214738+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86264960b95a901cd5c4172a3f5ea870cb5294038a4e8074dfd75c7d001ad48c
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220617-061406+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220617-061406+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9b66a06d50fc5e2ef5eab8901a813f5e49474d9ef22c44df260aa1a3925d5ed
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220618-061413+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220618-061413+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3368cc774e9c4cb65288cc76f81709ad004769ea69f49b2c88549599da0fbc0
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220619-152730+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220619-152730+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be2af712dbd08e7737efe8d0629abac02b4f40f62e8771017153aa26c01a3e50
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220620-061336+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220620-061336+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2b1f44b2794c132c657195fb69ca58ee53c64582525ba2eb57ef48356b233a0
-size 3964

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220621-061343+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220621-061343+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b6214cb977c054b414c668bcdf7681c94912ff88256e2499e9f385c6cf4d4ce
-size 3972

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220622-061435+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220622-061435+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07a5a310db7d085fdec1dd1fc2ba3810865dbc9695a7dc10d4a0296c8ab21c19
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220623-061423+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220623-061423+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3aee6470f6e61912e04f5b477375cf7bc3065c921aa380756a87f9d35bffd916
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220623-173728+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220623-173728+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c059aed787da3f57f2f61b754b5aba1f9f5976f05c83f0d542881f4c55dada79
-size 3972

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220623-225329+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220623-225329+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:379a16c20e6f52d1780a9c8624f91e93d605e5923f3928a775a349e04b841c8a
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220624-061407+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220624-061407+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ebf5d726e92ce254d57e5541080670fe1946dc83e82c35c227081c814ab94c3
-size 3972

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220625-061228+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220625-061228+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f1da8d52b619b70ea96712243c52c0eb5ae5a36b4a69a4b752ec1402e30ddab
-size 3972

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220626-061237+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220626-061237+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3eff6fc327ddd933dd6274590ad8ea183b661ef5c4dcf03a02cf5626fac9beaa
-size 3976

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220627-061248+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220627-061248+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8cd1c0858b2ba1b05907a92a5ef863658e2c1a8f29742e1ee6773a81373bcc1
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220628-061330+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220628-061330+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bed30afdf19227caa9b553c06b24bd3fd18d0a7a82b92010070a49b2cb799442
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220628-152011+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220628-152011+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f423913c7e36e8bd9655ec8375f5fb82ae03ac0ecbabf840705db1d394441138
-size 3968

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220629-061340+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220629-061340+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:820a14ad8b4ca396c9d977c02f9d0ba098816e13e8e4365148b91e6df6d73aa3
-size 3964

--- a/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220630-061303+buster_amd64.deb
+++ b/workstation/buster-nightlies/securedrop-workstation-grsec_4.14.241-dev-20220630-061303+buster_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:179a88a3a8eea4ec618b64b21f599859cf3ec1d7ee3b5a8f784e2ab03fb565d0
-size 3964


### PR DESCRIPTION

## Status

Ready for review

## Description of changes

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/793>.
