### PR TITLE
Add securedrop-log bullseye package

### DIFF
--- a/workstation/bullseye/securedrop-log_0.2.0+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-log_0.2.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f5dc86f73a936b3e90b44df31faef3939ac0021dffe838bf6ee2b923dd29e8d
+size 551316


### PR DESCRIPTION
## Status

Requires signing

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/commit/e6d369d17efc821b3c004f097c001be339a26ce8
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/3cea2408cc710618d1a44d69874864aa4a17e50c

