### PR TITLE
Add securedrop-export-0.3.0 bullseye package

### DIFF
--- a/workstation/securedrop-export_0.3.0+bullseye_all.deb
+++ b/workstation/securedrop-export_0.3.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:119fbac9fcbb0bdc61e2ce56e6d7fc8d08f528e8429e5d1cd0e70127573d8d09
+size 527020


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/commit/509f8c38555a52554344214e8e33df5cfa7f8cc4
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/354a1cc554b47ca1cf2df91759351d4d2d499a57

