### PR TITLE
Add securedrop-proxy-0.4.0 (bullseye)

### DIFF
--- a/workstation/bullseye/securedrop-proxy_0.4.0+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-proxy_0.4.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e57f27e9aa7f0d10bbe8dfe7c8c27a2e728ab2895b0c353b0ff4b773f9c8ab7e
+size 1435608


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/commit/7cc7f07b70450e8a8441be9b3c04610044e83f95
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/1a0be9bbdd81a83066da017eb04f8afdbea11e14

