### PR TITLE
add securedrop-workstation-viewer 0.2.0 package for bullseye

### DIFF
--- a/workstation/bullseye/securedrop-workstation-viewer_0.2.0+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-workstation-viewer_0.2.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e8f25702d95412395f9fba5e5340825cd989d043506608ec539f9382bf1ca3f
+size 1572


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/357
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/ad530d922da47f06b522ea553115d7bfc3742ff7

