### PR TITLE
add securedrop-client 0.8.0 package for bullseye

### DIFF
--- a/workstation/bullseye/securedrop-client_0.8.0+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.8.0+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3559561d24bcdc6393a72b67ac9b78c9756e49e92086c8f9385ae61c387a03a
+size 4005904


### PR DESCRIPTION
Signed-off-by: Allie Crevier <allie@freedom.press>

## Status

Ready for review / Work in progress

## Description of changes

## Checklist
- [x] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging): https://github.com/freedomofpress/securedrop-debian-packaging/pull/360
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/ec1e5cbeca2e3bca964b3f4e00a05ba328ea0b05

