### PR TITLE
Added SecureDrop 2.4.1-rc1 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.4.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.4.1~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:511fc6e77db1a0ae25d49076953364aee7e3af906f938728ed31861dd28ded01
+size 13595824

--- a/core/focal/securedrop-config-0.1.4+2.4.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.4.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdaaa4d9890432f076f2473138330aa8e141d9bbbeaa6a1acf4bedafb8da38ec
+size 3120

--- a/core/focal/securedrop-keyring-0.1.6+2.4.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.6+2.4.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28116e755c6adb6080ab60346ed4ac3bef7bd49eb7e3ed9eefe4a002e61c399f
+size 3728

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.4.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.4.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5024edc37abe2db921ed12ea1fd4dcb9fe9169373863bcfcd0aaa1470eb2e909
+size 4668

--- a/core/focal/securedrop-ossec-server-3.6.0+2.4.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.4.1~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522a18f89a57e2ff65552e28f47b1a59f94a00ade79267b737771d4baa1f1291
+size 8640


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build logs have been committed: https://github.com/freedomofpress/build-logs/commit/3023846f2b85b027d22b748e7cf4356b7a17ae7d.
- [x] correct tag was used in build logs
- [x] hashes in build logs match those of the files in the PR.

