### PR TITLE
Add SecureDrop 2.4.2-rc1 debs

### DIFF
--- a/core/focal/securedrop-app-code_2.4.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.4.2~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e62e60bd06f2dbb9ed1a0caea133d40c53c15283469946e9e02c41281b18681
+size 13595484

--- a/core/focal/securedrop-config-0.1.4+2.4.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.4.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670b2e9e994d39f50e5b4af2486e5f63153cc74d1253d9558ce1dc8e059751ea
+size 3120

--- a/core/focal/securedrop-grsec-5.15.57+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.15.57+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed6389b046962c2a41e16ca852675b6a840bc7929d233bc6406640c15478310a
+size 3048

--- a/core/focal/securedrop-keyring-0.1.6+2.4.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.6+2.4.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2519a45b5776117aa4e9e9a4eacb96c211c24a131c0b8ed53bba7c54962202b9
+size 3728

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.4.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.4.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4917657389e79ea7f0a2fa8f983f8ef3954c31de2906f32599979d02368ad57
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.4.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.4.2~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf8e5052b37623be98b1e607c458c4279f2b8934afd1f1d305aafc6be2d7eee2
+size 8636


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed: https://github.com/freedomofpress/build-logs/commit/998f1cf1894db44fa352f953ff4b729856ff9c6b.
- [x] correct tag was used in build logs
- [x] hashes in build logs match those of the files in the PR.
