### PR TITLE
Add bookworm repository configuration

### DIFF
--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -22,3 +22,11 @@ Architectures: amd64
 ValidFor: 6m
 Description: SecureDrop Workstation packages (bullseye)
 SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C
+
+Origin: SecureDrop
+Codename: bookworm
+Components: main nightlies
+Architectures: amd64
+ValidFor: 6m
+Description: SecureDrop Workstation packages (bookworm)
+SignWith: 4ED79CC3362D7D12837046024A3BE4A92211B03C


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs https://github.com/freedomofpress/securedrop-debian-packaging/issues/369.

This will do nothing on its own until we start building bookworm packages.