### PR TITLE
Add SecureDrop 2.5.0-rc1 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.5.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.5.0~rc1+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51cb666b5016fe58bcb730b347150a689fd8f6a6e7777c89ba3cc058083c518e
+size 13538936

--- a/core/focal/securedrop-config-0.1.4+2.5.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.5.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a8019e85e04f409b3aa8c424eab222f382572811cb6707df11ca34d07e589db
+size 3116

--- a/core/focal/securedrop-keyring-0.1.6+2.5.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.6+2.5.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:246ac651e8492a477041e926895d8b5cca602ed351b4fde72110e43f8a0e2df6
+size 3728

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.5.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.5.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d2871f583470e1192b5d352a0c2f1dde1a10e321290089ea4c3bbceb56c9843
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.5.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.5.0~rc1+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5594cf19ccbf250a364d4d3a22b6164e49070d9e2c36c35f78ada70e338ce2ef
+size 8628


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build logs have been committed:  https://github.com/freedomofpress/build-logs/commit/ccb9aa1425b6e919f5fa73c05b8b70ae106e2249
- [x] hashes of packages match those in the build log
