### PR TITLE
add SecureDrop 2.5.0-rc3 packages

### DIFF
--- a/core/focal/securedrop-app-code_2.5.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.5.0~rc3+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9477d5c691748431bb92adfc177832270f0a0a13bef974dd2bcab9872c5cb577
+size 13538340

--- a/core/focal/securedrop-config-0.1.4+2.5.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.5.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2c534f9a1875c74a1d6b44e0205d8602d529b7512e065842516b47ae47f0f7c
+size 3116

--- a/core/focal/securedrop-keyring-0.1.6+2.5.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.6+2.5.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48ac278edee07080bf484310b9a6174ed1726d9157e5de5261c14ed9f8859fad
+size 3732

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.5.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.5.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17fc344912d4abd5b5386f868c1356a03ebcf2239a5f34f351cb669d3feead46
+size 4664

--- a/core/focal/securedrop-ossec-server-3.6.0+2.5.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.5.0~rc3+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0eee429a40060b9969b6e0fbf5b0bb1fd19c401457ef0fd637c3b8b9d30914a7
+size 8624


### PR DESCRIPTION
## Status

Ready for review

**NB.**  No packages were published for the aborted SecureDrop 2.5.0-rc2.

## Checklist
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs):  https://github.com/freedomofpress/build-logs/commit/99d905929bc5b244e7f8d1859b178807b2806b7b
- [ ] Hashes of packages in this branch match those reported in the build log