### PR TITLE
Add SecureDrop 2.5.0-rc4 debs

### DIFF
--- a/core/focal/securedrop-app-code_2.1.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.1.0~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24f2cf7e068750259235130aecde1e2aa87d02a2f3cb40eeef79fdc5f9078994
-size 12761388

--- a/core/focal/securedrop-app-code_2.1.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.1.0~rc2+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40ec5664a36218004ffc00a3d2d860c3c3789fb14e3cc2fc4f2766bf72874793
-size 13684476

--- a/core/focal/securedrop-app-code_2.2.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.2.0~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19ee9dd420e51821f331aa24dc55f704ee418c1775a290fb2f3430783b4c8505
-size 13662136

--- a/core/focal/securedrop-app-code_2.2.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.2.0~rc2+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cb3d76f10221b7196f3a5e5d29e9be48b80acf2954c898b39c0d41acabb3872
-size 13659012

--- a/core/focal/securedrop-app-code_2.2.0~rc3+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.2.0~rc3+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc3e0e4179bf7913afae6e56b251c6585f04861f5757829f57ddf781e22d8939
-size 13659688

--- a/core/focal/securedrop-app-code_2.2.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.2.1~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9a52a08e99d8239902363b3623ae68e8b1ff9a270a2c87be9cea1fd69a98781
-size 13667612

--- a/core/focal/securedrop-app-code_2.3.0~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.3.0~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a2473ae2305195463efc4442a389067792a2037d271dc0076048018bee5ad13
-size 13668568

--- a/core/focal/securedrop-app-code_2.3.0~rc2+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.3.0~rc2+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:947fbe6a9da856e663b078ba83b1deb8b5fa0e0676a017fff321c5c727efc495
-size 13668252

--- a/core/focal/securedrop-app-code_2.3.1~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.3.1~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6003d67edeeee418bd9ee1ec2f28881e12813aa0d9fbed9f5ee413f454eb2200
-size 13679348

--- a/core/focal/securedrop-app-code_2.3.2~rc1+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.3.2~rc1+focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:972da46c570ea8d4334b71c0e53ffbb5c854e52b0054c7b31867bce47a3967b9
-size 13679120

--- a/core/focal/securedrop-app-code_2.5.0~rc4+focal_amd64.deb
+++ b/core/focal/securedrop-app-code_2.5.0~rc4+focal_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef217f48bb9cac78d42c2bfbbf9403cf5bc542f8589b9c85873ae960f9817c0
+size 13539604

--- a/core/focal/securedrop-config-0.1.4+2.1.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.1.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41bdd502ee65fe6e84416739cdac957cd348016803d7f1dbfdab6e8faeb3865a
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.1.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.1.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:424412d413b9ff806d3a26ae6058983aae8bcc59de284758c05da4612483d6df
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.2.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.2.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ffaefd5fbfcde144e6d72c0c0c4cd74ce062f9a9f3a5f3ab721420993e6eaac
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.2.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d9ad6de7740b1d46fad952577dc9e2db0a54815c4d09c8f615734e6aba39191
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.2.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.2.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b203387bb475ad1391b677d707b97b8e9a1fc0540f5fd2daea67ae1d29d3d4c9
-size 3068

--- a/core/focal/securedrop-config-0.1.4+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.2.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7299e54a32cbc08064b83c23bef9d80405caf60725607d7217196135035a7b1
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.3.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:486ad9989b10f4bf144523c9e4cbc918be3f1c6f437055217d65933ec14ab4cc
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.3.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.3.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82cf668cdef61bfbe7362b1e55c869fae7b15fe5adedb5562109b940b6537e87
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.3.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.3.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b64cadca2fedbddc1c4252a8153040018736101046f01e9242476dc1b3cfa1f9
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.3.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.3.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc82ebbdc7be6648c2da8c6364e66b22bdbea31ad0a80e552e10b5745f2879c2
-size 3064

--- a/core/focal/securedrop-config-0.1.4+2.5.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-config-0.1.4+2.5.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:714000822769acb5b84e3695ad283cb9a09446cb425001bf823502e739ac138f
+size 3116

--- a/core/focal/securedrop-grsec-5.4.136+focal-amd64.deb
+++ b/core/focal/securedrop-grsec-5.4.136+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05e248bc6da3047803d9a93c3eb70b903e8f0e1ba4925da074816b249905753f
-size 2996

--- a/core/focal/securedrop-keyring-0.1.5+2.1.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.1.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2be7decb8a56b109fcf1bf974058aca3c5652bc7bd631fedc2045df196816764
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.1.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.1.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1fa9d8099555f157ad00f055cc860a147e723c3cb66ec135e6434ef713ff8444
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.2.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.2.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6415b1115952a06ddaaaa6c46913f49c96dff7ccaedd9eef99f4a28a79cbaeec
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.2.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bfb5b773cf321b15dc318e78807554c60c76fb9b5dbc7453d5d1314c220daf8
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.2.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.2.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f32f5da44ceec6c58920b7a9debfa378dcfaf2a7f32efd93d1bc5d5900691f54
-size 3752

--- a/core/focal/securedrop-keyring-0.1.5+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.2.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dfe170b1d37cad4dae6a653cf2d1d7f6bb7fab41662d57d77fea9b6407f62116
-size 3752

--- a/core/focal/securedrop-keyring-0.1.5+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.3.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c746831843bb66cf8bab27657ea755f15b4cce02358d92d36cd3bc132bc3302e
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.3.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.3.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b3510f37624bdcfac87a103b09100c00bf69f72c2b63e62db647450fd84f3be
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.3.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.3.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7fe1cb8109cbcfa43978174e7dd1ce8e196a1deeb066a6bfff20cd195844bf1
-size 3748

--- a/core/focal/securedrop-keyring-0.1.5+2.3.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.5+2.3.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8423c32dd88fb2aaab4085c88b52f259f8de410c9cb24b984ef0e7cb863b716
-size 3752

--- a/core/focal/securedrop-keyring-0.1.6+2.5.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-keyring-0.1.6+2.5.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aaa5a49a3859626335d0cfba7008af064f4c8d362268cd327add88b7af8692d3
+size 3728

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.1.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.1.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:600d0b04e6e619206862cc5bbf0dbe718023258967409ac6bea2363ea1cb77bb
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.1.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.1.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:92fe690bd5dd8ddb2e98a6eb17e16498dd3c90b459fcef97a8300c1fc70f7fd4
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bec0ab83316b03991d27df57acc91d9f59161361d584be94708a9c41c3155f77
-size 4668

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10f6186fffe7331c0a36eb5faea79884e6d65937795c230bb03be184d89e6344
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.2.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55c1cca57fb0cfce4d5218f55f4892d5338e2b81d58a6b7a00f1d87e068f06e4
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.2.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c855429aaa46ec4cf346fb8ceb9807f82b82a770cee3cddf73652b1110047a6c
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.3.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf00f17fc2bcdd65d1488b949e10c92523193ea3f9acbd41f3878f59a4244bc1
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.3.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.3.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dda75b0b74d0dc7f1eb7178529f51c07e4f0bbf3bb3f0c45fb44a08d90380dc
-size 4668

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.3.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.3.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d49659469b971903074c5375529958e8bc1f55552784c2acb75e669c65ccd3bf
-size 4664

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.3.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.3.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:296957cd417430842bf6f352487814396f42ce5819e27a9cce4a11b00c7ddaf7
-size 4660

--- a/core/focal/securedrop-ossec-agent-3.6.0+2.5.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-agent-3.6.0+2.5.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f370a72f83dc93e54ed54f94e0fe5409735ed33029a9431c70194c9bba6ef3a
+size 4660

--- a/core/focal/securedrop-ossec-server-3.6.0+2.1.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.1.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1cd5d088450f201e9cbfffbdbf1328d62e3bf3a00a990f7141105ece278d161a
-size 8640

--- a/core/focal/securedrop-ossec-server-3.6.0+2.1.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.1.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e1f7cd12c8c3c2cab6c2a40b77c3887d6c1e3b73ea947e93e8c5dfa86e1203d
-size 8632

--- a/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b85e0aa10b5d682ccde63c09f7bdf7e354b29852af891b94cd33865bf820ad8
-size 8640

--- a/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb1dde3012d7d729b083f0711b72b88f684d5fcb9cf5af3b140b1c5c463227d0
-size 8640

--- a/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc3+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.2.0~rc3+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3c9de5f58d6b53599935fe6fd0da0cc750ea0b5fa00afb11449c19efdcb79d0
-size 8636

--- a/core/focal/securedrop-ossec-server-3.6.0+2.2.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.2.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aac35208babe1cf9a40e1d6deab6f26c57f4d21dff4838d22eeb8fea5f4809e2
-size 8644

--- a/core/focal/securedrop-ossec-server-3.6.0+2.3.0~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.3.0~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2a2dff1efab83bbe7cbd0dc28fcb328ee87e91b8ca8a3412f8bac41be7c0fbf
-size 8640

--- a/core/focal/securedrop-ossec-server-3.6.0+2.3.0~rc2+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.3.0~rc2+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:522b5cb438d1349a7c352a7803a40b7beed2b6f414cc17438810d081a56ca508
-size 8636

--- a/core/focal/securedrop-ossec-server-3.6.0+2.3.1~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.3.1~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e38c9ecede2af08b7d917c3f4b1c8dbcedf075ea5cd3f4faeaa7b2ce0f5d096
-size 8640

--- a/core/focal/securedrop-ossec-server-3.6.0+2.3.2~rc1+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.3.2~rc1+focal-amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6aa0407c5854e49af404e5e7d7f55ae31cfdba063fb84fd2b18ac5e57f5dcf2f
-size 8632

--- a/core/focal/securedrop-ossec-server-3.6.0+2.5.0~rc4+focal-amd64.deb
+++ b/core/focal/securedrop-ossec-server-3.6.0+2.5.0~rc4+focal-amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88f671db4e75656b86287cfdede98d2240dda0a9cdc5ac14f99a806e6ef708ac
+size 8620

--- a/core/focal/tor-geoipdb_0.4.5.10-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.5.10-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73bb1771b652949d56cbd84082d1008d46ea4e333dcacbd5a38bf1d0299c1b06
-size 893124

--- a/core/focal/tor-geoipdb_0.4.6.10-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.6.10-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ae408ce76826f36ecc7f54eab45fb036c0379e831421066f9a7b457c9cd8fbd
-size 913624

--- a/core/focal/tor-geoipdb_0.4.6.9-1~focal+1_all.deb
+++ b/core/focal/tor-geoipdb_0.4.6.9-1~focal+1_all.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19e10e5ebeff89f00c83f27ff64762671bec9f37d68c90f869c81d69544bdc36
-size 912204

--- a/core/focal/tor_0.4.5.10-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.5.10-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2899925514f97155fd7cafecd7be7a4ca5b0f616104632e878bbde18951fc1a
-size 1487840

--- a/core/focal/tor_0.4.6.10-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.6.10-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:878ae2ee4baf7b3e9d55a78ec6ae1962e403b06d2b77a0e18ec1a953b551c98e
-size 1446200

--- a/core/focal/tor_0.4.6.9-1~focal+1_amd64.deb
+++ b/core/focal/tor_0.4.6.9-1~focal+1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c198f323caf0692a120e548d76de2bf177322cd9208ba3c352aca2007e18003
-size 1446952


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Adds SecureDrop 2.5.0-rc4 packages.
Removes older SecureDrop (< 2.4.0) and Tor (< 0.4.7.*) packages.

## Checklist

- [x] Build logs have been committed: https://github.com/freedomofpress/build-logs/commit/694405228860dfb20962bc77f5ac7ec64ec2f0ee
- [x] hashes in build logs match those of the committed packages.

