### PR TITLE
Add Linux 5.15.81 packages

### DIFF
--- a/core/focal/linux-headers-5.15.81-grsec-securedrop_5.15.81-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-headers-5.15.81-grsec-securedrop_5.15.81-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a853a2f0eb3e4494eb6ad1ea6e432a3e1976876b5b26bd129e7717103a1ded7e
+size 24313508

--- a/core/focal/linux-image-5.15.81-grsec-securedrop_5.15.81-grsec-securedrop-1_amd64.deb
+++ b/core/focal/linux-image-5.15.81-grsec-securedrop_5.15.81-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0be10cceb568c2b1b9c546e0e4f8ab1af8cb159f03fce13f1652a39d27988dd4
+size 59289512

--- a/core/focal/securedrop-grsec_5.15.81-grsec-securedrop-1_amd64.deb
+++ b/core/focal/securedrop-grsec_5.15.81-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20b9039ace1b90f8f00e5f831eaae8a1aecb42a779d85ef9966d368f8efac30
+size 3012

--- a/workstation/bullseye/linux-headers-5.15.81-grsec-workstation_5.15.81-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-headers-5.15.81-grsec-workstation_5.15.81-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fef6848b156fc906e19a988d3aec5688a9c6f12f2373b08b6597ac7cb9d0457b
+size 24265748

--- a/workstation/bullseye/linux-image-5.15.81-grsec-workstation_5.15.81-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/linux-image-5.15.81-grsec-workstation_5.15.81-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e666b9341e7b0ff620479ac6b77c1e088eb5a602142f86ae9e71c3e03d0b792f
+size 48094196

--- a/workstation/bullseye/securedrop-workstation-grsec_5.15.81-grsec-workstation-1_amd64.deb
+++ b/workstation/bullseye/securedrop-workstation-grsec_5.15.81-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6347e060f3f121de29752a8853c2a17600ceb211c815b3e4b7154443e5c9074
+size 2444


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs https://github.com/freedomofpress/securedrop/issues/6697
Refs https://github.com/freedomofpress/securedrop-workstation/issues/847

## Checklist
- [x] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs/commit/11cc50d8be616d9c82684f865c5413956fcf9d05).
- [x] Tarballs have been uploaded to S3.
