### PR TITLE
Update pull request template for securedrop-builder rename

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@ Ready for review / Work in progress
 ## Description of changes
 
 ## Checklist
-- [ ] Cross-link to changes made in [securedrop-debian-packaging](https://github.com/freedomofpress/securedrop-debian-packaging).
+- [ ] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder).
 - [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs).
 


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

Refs https://github.com/freedomofpress/securedrop-builder/issues/304.
