### PR TITLE
Add securedrop-client 0.9.0-rc3

### DIFF
--- a/workstation/bullseye/securedrop-client_0.9.0-rc3+bullseye_all.deb
+++ b/workstation/bullseye/securedrop-client_0.9.0-rc3+bullseye_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b65ae21bf6593720727e0cbee9336e229002a8ddcd384d1f1bd3bce1162a94ff
+size 4117352


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [ ] Cross-link to changes made in [securedrop-builder](https://github.com/freedomofpress/securedrop-builder): https://github.com/freedomofpress/securedrop-builder/pull/425
- [ ] Build logs have been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/9070b748c56eb7ddccf5af24c0c5c9378069409f
- [ ] .buildinfo has been committed in build-logs: https://github.com/freedomofpress/build-logs/commit/9070b748c56eb7ddccf5af24c0c5c9378069409f#diff-241c2678acd610bf6ee3bf911787dcf6b2b4ff8116c773f6f975799dbd8e57f9  

