### PR TITLE
Add securedrop-client 0.14.0-rc1 packages.

### DIFF
--- a/workstation/bookworm/securedrop-client-dbgsym_0.14.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_0.14.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96d0c009a2c7f2f91a063da339f5fbec7f0d35f81652c5ae34d3139a28e10b33
+size 49716

--- a/workstation/bookworm/securedrop-client_0.14.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_0.14.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e5e70e4f96444767293594b126f8dd8c5486b2e3f7cdbb034ce6d5c343b7e86
+size 4927744

--- a/workstation/bookworm/securedrop-export_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e620260f69695f7c2df1bdd88d8b51d7f22d1224a425f12acd8da55e770d163a
+size 1643568

--- a/workstation/bookworm/securedrop-keyring_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9fb80c549746ebe6f87929c13311976b4c4f026a1e7fce70b614b4faec112c3
+size 9984

--- a/workstation/bookworm/securedrop-log_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01d4ce8c32cf1aa3db88824d963060349899ddce565bc1883ff753ba941edfb8
+size 1611396

--- a/workstation/bookworm/securedrop-proxy-dbgsym_0.14.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_0.14.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5018fa10979519c5d88cf6b8ff5a5dca029c90e3da7354247eabf764ff5efe66
+size 10946688

--- a/workstation/bookworm/securedrop-proxy_0.14.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_0.14.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c95bee42c0827fcaddfbb9e745fe0cbd9699364a310dc7cc839900f8c460925e
+size 1042820

--- a/workstation/bookworm/securedrop-qubesdb-tools_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-qubesdb-tools_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cce8fcf932681e4fee5c84022c1082bbe9d2ad0e4002ee1f7c64935a3933012
+size 4136

--- a/workstation/bookworm/securedrop-whonix-config_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-whonix-config_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e66a35e2e017a48c521839d4cdb0dc89dd63a50a56e727502430b86baab3d29
+size 4704

--- a/workstation/bookworm/securedrop-workstation-config_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4c981614f62d1a72a89af09d0e38e2cf46d14c5aaaad39fa6a949974bc71c60
+size 9464

--- a/workstation/bookworm/securedrop-workstation-viewer_0.14.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_0.14.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0ff7bbf691c4ad4dd256ea11264102a0e5cfbab66d01d03e4571f02455491cd
+size 3684


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build logs have been committed to https://github.com/freedomofpress/build-logs/commit/066a6791c685a6d20f41f9c9cf4b2cb59089d4d5

