### PR TITLE
Fetch Tor packages for bookworm

### DIFF
--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -35,7 +35,9 @@ jobs:
 
                 # Copy the new packages over, intentionally leaving the old ones around
                 cp repo/public/pool/main/t/tor/*noble*.deb core/noble/
+                cp repo/public/pool/main/t/tor/*bookworm*.deb workstation/bookworm/
                 git add core/noble/*.deb
+                git add workstation/bookworm/*.deb
                 # If there are staged changes, git diff will fail, so we commit and push
                 git diff --staged --exit-code || (git commit -m "Automatically updating Tor packages" \
                     && git push origin main && ./scripts/new-tor-issue)

--- a/repo/conf/updates
+++ b/repo/conf/updates
@@ -1,3 +1,12 @@
+Name: tor-bookworm
+Method: https://deb.torproject.org/torproject.org
+Components: main
+Suite: bookworm
+GetInRelease: no
+Architectures: amd64
+VerifyRelease: 74A941BA219EC810
+ListShellHook: grep-dctrl -e -S '^tor(-geoip)?$' || [ $? -eq 1 ]
+
 Name: tor-noble
 Method: https://deb.torproject.org/torproject.org
 Components: main


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-client/pull/2676>.

## Description of changes

* Copy our Tor mirroring logic to apply to bookworm too.

