### PR TITLE
removing persistence of token to git config

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -77,5 +77,4 @@ jobs:
             run: |
               # Index will be clean if there are no changes
               git diff-index --quiet HEAD || git commit -m "Signing new packages"
-              git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-              git push origin main
+              git push https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git main

--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -48,7 +48,7 @@ jobs:
               cp repo/public/pool/main/t/tor/*bookworm*.deb workstation/bookworm/
               git add core/noble/*.deb
               git add workstation/bookworm/*.deb
-              git remote set-url origin https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
               # If there are staged changes, git diff will fail, so we commit and push
               git diff --staged --exit-code || (git commit -m "Automatically updating Tor packages" \
-                  && git push origin main && ./scripts/new-tor-issue)
+                  && git push https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git main \
+                  && ./scripts/new-tor-issue)


### PR DESCRIPTION
## Status

Updating based on feedback at: https://github.com/freedomofpress/securedrop-workstation/pull/1439

Relates to: https://github.com/freedomofpress/infrastructure/issues/5789
