### PR TITLE
Add securedrop 2.15.0-rc1 packages

### DIFF
--- a/core/noble/securedrop-app-code-dbgsym_2.15.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.15.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b33914b1b2641293e13db22be3af953185819fd1ea47f9563c908954c79a920
+size 1029834

--- a/core/noble/securedrop-app-code_2.15.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.15.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36ce66947b9ca342ba0169f0adc3b361f3d963dcabb489c13a957226ecaf5dc6
+size 14460282

--- a/core/noble/securedrop-config_2.15.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.15.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:064cd30747ce09de8485f06d4438bca713441391602b76a841dc6d8c92d4ae3b
+size 6654

--- a/core/noble/securedrop-keyring_0.2.2+2.15.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.15.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8075e4fca127eea92e8961149d07ddc54fe320bef7a0f13a5eac973d86a15ffe
+size 7536

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.15.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.15.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aca96ccadc9e62f5ac75f7fdf99f5a8065d393d4da06e3613fe6ae5c82f1107a
+size 5198

--- a/core/noble/securedrop-ossec-server_3.6.0+2.15.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.15.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a9543e61d3b16e723a29c12aadd396ec8c17a49cbf627522d69164357169eb6
+size 9192

--- a/workstation/trixie/securedrop-admin-dbgsym_2.15.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-admin-dbgsym_2.15.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3df0f8a10fd5ba5b9cbc9f7bcaef55c94144018e4a9fefff5857e4357fa49e10
+size 888568

--- a/workstation/trixie/securedrop-admin_2.15.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-admin_2.15.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad7f7aeb72c2096158beb6b5978fdb2fda2ad4b89f893691a31745ed516e3d53
+size 25338368


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

## Checklist
- [x] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/5350b8dd5391819b59194e1d27e89e4f115c9016
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] ~~Build locally and compare sha256sum hashes (if reproducible)~~
- [ ] ~For kernel packages only: source tarball uploaded internally~
