### PR TITLE
Add SecureDrop Inbox 1.0.0-rc1

### DIFF
--- a/workstation/bookworm/securedrop-app_1.0.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.0.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7286374b9ec8f9b955c67c26b2466d21ac0fed3192308628c5f511f470c56390
+size 96050512

--- a/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a94bd10d272f7d96cd693928eb30fd969ccb0ad7ac5213c5c7d04f7e2f89844
+size 49712

--- a/workstation/bookworm/securedrop-client_1.0.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.0.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a912674a41db619c15d8ef51a9a7e0c5c7088632464e7e114c1e3416fa2c769d
+size 3895120

--- a/workstation/bookworm/securedrop-export_1.0.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.0.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d54cd2083baa743186a785f20fe33895676da023ddd3259dbd8f0283368a82db
+size 1643644

--- a/workstation/bookworm/securedrop-gpg-config_1.0.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.0.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9535a3ce6013d08a5287d129b0732f3a1e437506c12d7244dcfedc5b22386164
+size 5144

--- a/workstation/bookworm/securedrop-keyring_1.0.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.0.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0725445328413ff6a0f153ece2980ce09f88153f13cf62f8529700293f502765
+size 10184

--- a/workstation/bookworm/securedrop-log_1.0.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.0.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:053a93298de365a04acfc1045ba0e753080a1ad5fcbbe2a3bdbb69ef751507b0
+size 1611992

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e55d29d2635fadcaa0ba56a31876d9042de13411b61f7c64d6783b6a17fbd7f1
+size 12354240

--- a/workstation/bookworm/securedrop-proxy_1.0.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.0.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e02e06433ef66ab82ae78f58b3ca4b6552bad3c1d983b0dcc5a7efd171125d32
+size 1043940

--- a/workstation/bookworm/securedrop-workstation-config_1.0.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.0.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bba432de66deb428ae144a852087dd3e4f1199225f12e0a39d400822ec8c7020
+size 9248

--- a/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a5a32e8166600d515d90c639bb73b2b05a4000e231042bad5bab352691a9955
+size 3904


### PR DESCRIPTION
## Description of changes

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/40ba8e1f49d6fe1b3638f51e8b1b86a2dc3f4bf5
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes
