### PR TITLE
Add SecureDrop Inbox 1.0.0-rc2 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.0.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.0.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ddb4be665e515d67204a1b86e978dd9d285cd891df0d507ccec140acd1a1aef
+size 96036528

--- a/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a17117a8b88b6f5934e970091c718a3a41d0812c5a1605d9a243bd81bb5925ea
+size 49712

--- a/workstation/bookworm/securedrop-client_1.0.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.0.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b7d1449233b979b9b4cf8e17cd5d9dbf09d8e3171a1abf06691dc2f7a0b1536
+size 3895520

--- a/workstation/bookworm/securedrop-export_1.0.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.0.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d176a5fe5e4113448718cf1543333be610de0d6af3250feaff00d433c1bf9d24
+size 1643536

--- a/workstation/bookworm/securedrop-gpg-config_1.0.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.0.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b80251c9a08e1eeae91d71daf232d69d4a029822abdce969ca4910949ecc143
+size 5132

--- a/workstation/bookworm/securedrop-keyring_1.0.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.0.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:742ec0eaa8a6dfa23159911e423937ea38f76a5bc73020db06dd782f75698943
+size 10172

--- a/workstation/bookworm/securedrop-log_1.0.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.0.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da82910d9394c8c343e5acc32d31334f37a3ebab0eeacd4dce56bd4a90bd066b
+size 1611796

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2aa10f1a14f2fd67f5afde4016572d2836cc7d4a4c84d39f5d6894170756664
+size 12354168

--- a/workstation/bookworm/securedrop-proxy_1.0.0~rc2+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.0.0~rc2+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07cd97732d94022839be57b7847db54b2ab7a2ffa52675618a590e7d43720a38
+size 1043196

--- a/workstation/bookworm/securedrop-workstation-config_1.0.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.0.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdb0ed4f8d4eeef48bd663dcdfcfbc02b634f210ac981e74946d0c56e6696848
+size 9244

--- a/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc2+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc2+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ed7f5c4b99721c09695d3595d8f6c5129cc2a76e7f3f558811248f1f63147ee
+size 3900


### PR DESCRIPTION
## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/a308ff3992098385ef30158142b8da226cd17d87
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes
