### PR TITLE
Add SecureDrop Inbox 1.0.0-rc3 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.0.0~rc3+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.0.0~rc3+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b5b76ff6fcce7e09dee1c407a52297dd287f415160b6a9033f12f4dfa9a9a1d
+size 95992648

--- a/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc3+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc3+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18459c7ca170df4076e5e02f774807134771d22855f65973e13b3cb35fb823ba
+size 49716

--- a/workstation/bookworm/securedrop-client_1.0.0~rc3+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.0.0~rc3+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef0d510b0da5fb60c26c4e128b4e9c303e8e5312b846f7082dbc68fe949104fe
+size 3895516

--- a/workstation/bookworm/securedrop-export_1.0.0~rc3+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.0.0~rc3+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76173a6296596994b17bb63977857c20f8b0fc67d15ad35bdef0eab604e75fe2
+size 1643672

--- a/workstation/bookworm/securedrop-gpg-config_1.0.0~rc3+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.0.0~rc3+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:917ab41b2b9ee517c6fa14c96d777b7dc9ef43881043df51caa6d3821515a51a
+size 5172

--- a/workstation/bookworm/securedrop-keyring_1.0.0~rc3+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.0.0~rc3+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae935dd418d7e152f2839b2673825175e1793c049f763296bd8b5896c2d4f297
+size 10192

--- a/workstation/bookworm/securedrop-log_1.0.0~rc3+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.0.0~rc3+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2afe1d57c7c1fed902522585c3d671a87d8a7845704d6526629cda270c6ec0db
+size 1612004

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc3+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc3+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96541bdb6cef6e4acb0e97fbee7e74bfea50c5cda7c090b0875369e4a194924e
+size 12354172

--- a/workstation/bookworm/securedrop-proxy_1.0.0~rc3+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.0.0~rc3+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a56d59f059d1409df9417b8f71c2e45a543d1cc10f46bb1809454f868d6140d2
+size 1043100

--- a/workstation/bookworm/securedrop-workstation-config_1.0.0~rc3+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.0.0~rc3+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a2d3c7ec7ecb21a7bc1996ef93fc7a63f1c7720da366b2eacaafb3cac0052b8
+size 9276

--- a/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc3+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc3+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7272ce42be7f46126b5ce175edd6bb662f234b56245bfeaa1881f78c6e2206ab
+size 3928


### PR DESCRIPTION
## Status

Ready for review

## Description of changes

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/efe873ad7b4f14876f48696d08b873d7ce4f59da
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
