### PR TITLE
Add SecureDrop Inbox 1.0.0-rc4 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.0.0~rc4+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.0.0~rc4+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e434fb176594e316ea03d576e2c11790faa4ade258907d40c60c8e55578fb2f
+size 95994712

--- a/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc4+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc4+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ada9e5fd0e3515710314e59e04a2ebadbcb3c718e08c76676413a91d6fc9ab0
+size 49716

--- a/workstation/bookworm/securedrop-client_1.0.0~rc4+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.0.0~rc4+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19402c91329c05dee4bb50cdb929e97fb99c326342baee8064a651f5233bfe5f
+size 3895956

--- a/workstation/bookworm/securedrop-export_1.0.0~rc4+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.0.0~rc4+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57c034c4970182dc58707fc1a1065a93cb179744165838bb31840428ddd887fd
+size 1643816

--- a/workstation/bookworm/securedrop-gpg-config_1.0.0~rc4+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.0.0~rc4+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db2b96d79d3399ee06c63ccd70b7cbe130cd12f3a393e49c9bdb9d62f3c4805a
+size 5180

--- a/workstation/bookworm/securedrop-keyring_1.0.0~rc4+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.0.0~rc4+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:304d06444314839fee06070c91f3d6a8f8395fc66f659fe097da4b0d855cfd63
+size 10216

--- a/workstation/bookworm/securedrop-log_1.0.0~rc4+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.0.0~rc4+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3cb89d1b3882798486c50dd6b9a927ecd105d63a00509dce8673746ee34319e
+size 1612208

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc4+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc4+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb948773cb97cfafaddac0ea83a1a2c5b7d0e8ecaa44c4e0a19a4cf87ade4f55
+size 12354176

--- a/workstation/bookworm/securedrop-proxy_1.0.0~rc4+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.0.0~rc4+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84fd8b10c94579f4110189f451ffd397211ca246471906e9dab9fc97689df4dd
+size 1043484

--- a/workstation/bookworm/securedrop-workstation-config_1.0.0~rc4+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.0.0~rc4+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ed2b6fe6601b45e6478c164422b1ca55afcc845739e008376c2590765c3db57
+size 9288

--- a/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc4+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc4+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37f0076be9ab549023b44e8413358a7adb355c9c335c9615a7d46929c6fecfb2
+size 3940


### PR DESCRIPTION
## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/5818c9a74e81ec5b918b36d6d134700e4accba73
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes
