### PR TITLE
Add SecureDrop Inbox 1.0.0-rc5 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.0.0~rc5+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.0.0~rc5+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32e8e493efddbde787847b78bc11ad925e768523abf803d8e0acb8d8b6a604c4
+size 95973452

--- a/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc5+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.0.0~rc5+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec07d569e467d261302d02d87c5d97ee9d4807e35941cdc5f2ff9167eead8d6e
+size 49716

--- a/workstation/bookworm/securedrop-client_1.0.0~rc5+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.0.0~rc5+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0d79e089152eaafd0a47578f44255a0db839ba80906d55053c27c0ab580cb3a
+size 3895568

--- a/workstation/bookworm/securedrop-export_1.0.0~rc5+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.0.0~rc5+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:908cbd9ad5214e840bbb27b3bfa427912c95b268aa51a5dfb40752feb635c0ff
+size 1643356

--- a/workstation/bookworm/securedrop-gpg-config_1.0.0~rc5+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.0.0~rc5+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e6c17dcd696bfccea1b7e4e6625b16c4ebec68865e39be9e389daa73624b89d
+size 5168

--- a/workstation/bookworm/securedrop-keyring_1.0.0~rc5+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.0.0~rc5+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de74cde597d4ce1d3ae9705358ca466603c3b9cb190360088ee8352580cc5c6
+size 10212

--- a/workstation/bookworm/securedrop-log_1.0.0~rc5+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.0.0~rc5+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62825db144c41d2934e7e809271c811aa9421ebd3ad8f51a4ed699ba42165dba
+size 1612176

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc5+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0~rc5+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a8a153070de77b89600f35613df05d76060d6556b55acaf71489b015c8516f9
+size 12354328

--- a/workstation/bookworm/securedrop-proxy_1.0.0~rc5+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.0.0~rc5+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc9c7320eed7daa3282e5efdb798f929100c5592dede0ebfd6f42f2d15b606bb
+size 1043348

--- a/workstation/bookworm/securedrop-workstation-config_1.0.0~rc5+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.0.0~rc5+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d76f94ad7a5ab6a357f749a2653fc90cd7c8252362315e761c4eb382f9cbf1f
+size 9280

--- a/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc5+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.0.0~rc5+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:877189b517de0ea2e2d67744109bc59d2b1abde214c0150e891c45b80f5d6c7e
+size 3936


### PR DESCRIPTION
## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/850064960f38e676137642bdf4478ea9cc100a4b
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
