### PR TITLE
Add SecureDrop Inbox 1.0.0 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.0.0+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.0.0+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:537a27a012173ce13c651ea9721ad6e377dc8bfa58f82d75993d529135801088
+size 95979528

--- a/workstation/bookworm/securedrop-client-dbgsym_1.0.0+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.0.0+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c1b3b7e44af020e03e3b5ab1ebbb95997c4a79005aecfaaa43cbbfcd65ddca0
+size 49712

--- a/workstation/bookworm/securedrop-client_1.0.0+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.0.0+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccd1795b9a3175d222b8a92217e67d43015fe26d94b8a69e27da11ab6d444a68
+size 3895536

--- a/workstation/bookworm/securedrop-export_1.0.0+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.0.0+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1edd3d3a53b6c439aca8a8f661606f96cec60e47c252397515576049e7bae920
+size 1643704

--- a/workstation/bookworm/securedrop-gpg-config_1.0.0+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.0.0+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f880835a5dfb4017837039880c2025f110723895c4d0ccb8a133c2660e7a6693
+size 5128

--- a/workstation/bookworm/securedrop-keyring_1.0.0+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.0.0+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d232b0a5941dc04afa4cc19fdf1a3c64bf7b632aa455c090ec5d1ea452c5882
+size 10160

--- a/workstation/bookworm/securedrop-log_1.0.0+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.0.0+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebc16531749f3eeb852a99bdf0fbda2c90e54a6d1fd13dd5d1ed9a402f25c33b
+size 1611920

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.0.0+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ace8be4b728e5d2bb301e261d90923487a2e642b83c36ef08fdba5ebacf9b315
+size 12354304

--- a/workstation/bookworm/securedrop-proxy_1.0.0+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.0.0+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7622e6d243d4d8c8879400f7cc804368dad78fde218d9de1d41df0916c76ab69
+size 1043564

--- a/workstation/bookworm/securedrop-workstation-config_1.0.0+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.0.0+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c5ad2f3eb9b40b3495253610508414092f49e31bccae5d6a37436fba38ee94b
+size 9236

--- a/workstation/bookworm/securedrop-workstation-viewer_1.0.0+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.0.0+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fe5782ec64bb6bd1a6a67fc571dd7ed7d34b536074079be1358daed016f321a
+size 3888


### PR DESCRIPTION
## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/51d58141420f840cb8f265e999176c3438ead0e4
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
