### PR TITLE
Add SecureDrop Inbox 1.1.0-rc1 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.1.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.1.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c3a14bc03e704a4061016199dafaa7a9193a75da54f9f09c685d16c61032cc9
+size 95982876

--- a/workstation/bookworm/securedrop-client-dbgsym_1.1.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.1.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b4c6e5af6c3a71fab79b12370654905ec08afd0cd025ea765c0a58563b728eb
+size 49716

--- a/workstation/bookworm/securedrop-client_1.1.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.1.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b42441dd2aa4eacaca0141e67d6d4ccad1d99080d4cecfd7d7ebed8dc77f669
+size 3895912

--- a/workstation/bookworm/securedrop-export_1.1.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.1.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:761d82ce7ad01ecef1502b21a7cb6905cda1e5bd622ca4cce5a6dd318b708614
+size 1643684

--- a/workstation/bookworm/securedrop-gpg-config_1.1.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.1.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4928744bcf2f1ee9adedb689dcf002b94d0d93d33f3036de8f1f45dd1c618e4a
+size 5144

--- a/workstation/bookworm/securedrop-keyring_1.1.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.1.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feca91ff1bd9a36398d7448cda73f06e2eef76dbeb1546933613e6227d21e979
+size 10180

--- a/workstation/bookworm/securedrop-log_1.1.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.1.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbf922e15bc9273c3a06be8832c9d5538dbc5c7c659b67c40607b2d57552010e
+size 1611784

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.1.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.1.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5de17653829e0c1d91c746ab8a3d7332586a1089b798b41948a417df331bcf9
+size 12338820

--- a/workstation/bookworm/securedrop-proxy_1.1.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.1.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07ab39224e6f087e72b005c85714ca4e4c3ee11f99aa158e342efed136495df7
+size 1042864

--- a/workstation/bookworm/securedrop-workstation-config_1.1.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.1.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cd6831d3ac1bd4d8e0bce2a7c47ba7e4036e4e256fba19283ad9bf62fe0f79d
+size 9252

--- a/workstation/bookworm/securedrop-workstation-viewer_1.1.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.1.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66f3fdb0892e40de5bbce9fe9e027d32d901a8d31c1d7754dc8f17b91b2ab60b
+size 3904


### PR DESCRIPTION
## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/3b095d01e332a552faf78474e8352ef9c2cfb89d
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)

