### PR TITLE
Add SecureDrop Inbox 1.2.0-rc1 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.2.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.2.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74fa7494e64e08d1a7d1a21156ead9a4c31fb1afc50659b66f3e54336136c0a4
+size 95995724

--- a/workstation/bookworm/securedrop-client-dbgsym_1.2.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.2.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1405997293227486a68cb64c849324c00a16d8e5b1e0c4546341cde4daed8799
+size 49712

--- a/workstation/bookworm/securedrop-client_1.2.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.2.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2c68d744c42c193b8cddde174a41630a0a9d3d97b1997807f660881799a6646
+size 3895696

--- a/workstation/bookworm/securedrop-export_1.2.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.2.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abd1eba6a8f4c80ea370dbe6b71fd05c58ac49cc555d12b372a5532f373b3829
+size 1644084

--- a/workstation/bookworm/securedrop-gpg-config_1.2.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.2.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a28a486b38d12d7cdd5fe2986e9ffc4fbcaf8a6fae6bf93056742f6ed15f8151
+size 5148

--- a/workstation/bookworm/securedrop-keyring_1.2.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.2.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4b351d746b3f2bdc2c848d50d8816dfa541b3eb4861adcc1e87660a9b80fed1
+size 10200

--- a/workstation/bookworm/securedrop-log_1.2.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.2.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3ff41e0250d5b8b2d9386a0f5ec8924f562c894e4cb9cd0b46fd7fb4242cff5
+size 1612176

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.2.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.2.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6a5f33f1abf515b0059bd712a8e1c49717465e52b70abad8106b4831dc6decf
+size 12338860

--- a/workstation/bookworm/securedrop-proxy_1.2.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.2.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffa150ed10005de4465dec861ee868ec3e46e21085c5f382ea0c863b0adcdcf9
+size 1042924

--- a/workstation/bookworm/securedrop-workstation-config_1.2.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.2.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a90d4f544093718c63e031860b67515aa15de601a1641b655e1c842153b110e
+size 9272

--- a/workstation/bookworm/securedrop-workstation-viewer_1.2.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.2.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e94c93538e56c4bdbee1651242b45107f097df5bcdd56481c98efd215ea563bb
+size 3916


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of changes

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/d1f2df5cb2ec28ee10f498bde2d04cdc77ff0e25
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
