### PR TITLE
Add SecureDrop Inbox 1.3.0-rc1 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.3.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.3.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98e21ddeb1af25ac74c20eebb32a5be9e4e87f1ae2407c547ad9f575634f1d77
+size 97331704

--- a/workstation/bookworm/securedrop-client-dbgsym_1.3.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client-dbgsym_1.3.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e108068caccdf8bb5882a965d19a356cb579f700f3d76728355b4e0850f277
+size 49720

--- a/workstation/bookworm/securedrop-client_1.3.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-client_1.3.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af25121c4d4ea0236e572cee9f76765c90ebc9b244225e6e6878f1e0e72453e3
+size 3895600

--- a/workstation/bookworm/securedrop-export_1.3.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.3.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16eddf4f043afdbe7071624137c0a02bbf28c1e4497df54db07180e049591533
+size 1643212

--- a/workstation/bookworm/securedrop-gpg-config_1.3.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.3.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:127fb41e67e4e2ba324b0a699651a1ca7cee14d02bf9fe72850870c1d57891c7
+size 5168

--- a/workstation/bookworm/securedrop-keyring_1.3.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.3.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03e216c3310fe4d591d807a08cc07f28b78b236ea57cc252aff96f3027d756ac
+size 10208

--- a/workstation/bookworm/securedrop-log_1.3.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.3.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19a7fff14a3f736c751bfcde35db79e255b57dd0f2d5ea56be7a01e3cf5140ef
+size 1612416

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.3.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.3.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e57c715a593b529c859ad290efc9a6824a4d7f16d394feb5cc312e91ccd45152
+size 12338812

--- a/workstation/bookworm/securedrop-proxy_1.3.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.3.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a68ec7c697399bc552b082f81b7d42b897aaf9e7a617328c9ea0773e5ed3d37
+size 1043812

--- a/workstation/bookworm/securedrop-workstation-config_1.3.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.3.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf143acd86641ec67bc198fda9bb46e5776eab3ec6bb273e5e2c971814761a88
+size 9288

--- a/workstation/bookworm/securedrop-workstation-viewer_1.3.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.3.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f438237e1a63d2b29440c6b61194177ef504d13c307d68a0c9ae5428b1beac1a
+size 3936


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/9ec94deccf2a337e4733b1f4ed70314a0d364ccc
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
