### PR TITLE
Add 6.6.141 kernels

### DIFF
--- a/core/noble/linux-headers-6.6.141-1-grsec-securedrop_6.6.141-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-headers-6.6.141-1-grsec-securedrop_6.6.141-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cc43a00eeef47b422bf38277a63c6dcc26f4c1f9d0b6bf37c0a70a8d067bb35
+size 25113660

--- a/core/noble/linux-image-6.6.141-1-grsec-securedrop_6.6.141-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/linux-image-6.6.141-1-grsec-securedrop_6.6.141-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac73f1dbf062b86f6f85ef54db9653ab9f4e62675707cf51f5fa079a32dc7352
+size 71367256

--- a/core/noble/securedrop-grsec_6.6.141-1-grsec-securedrop-1_amd64.deb
+++ b/core/noble/securedrop-grsec_6.6.141-1-grsec-securedrop-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22544c4e5ac437bb3135508dd4a72689459b956aa427401c1d7509f433185d9e
+size 3328

--- a/workstation/bookworm/linux-headers-6.6.141-1-grsec-workstation_6.6.141-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-headers-6.6.141-1-grsec-workstation_6.6.141-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a4aee830bff99b0ee001dc8e9befbb4342cb4e3253529766e18b97dc9504988
+size 25146376

--- a/workstation/bookworm/linux-image-6.6.141-1-grsec-workstation_6.6.141-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/linux-image-6.6.141-1-grsec-workstation_6.6.141-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65863d45882fbe17303beff7396c12d737649827639830ca8ac85c8ce8fa299b
+size 55088868

--- a/workstation/bookworm/securedrop-workstation-grsec_6.6.141-1-grsec-workstation-1_amd64.deb
+++ b/workstation/bookworm/securedrop-workstation-grsec_6.6.141-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd6374c00fe895e906bce7a0d117dc9594428160ec0c6c7a05dacbd1db79a089
+size 2060


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

## Checklist
- [ ] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/5644bcdc2809fad6eb1b1b87d4d6ec6d6e3fa75e
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] ~Build locally and compare sha256sum hashes (if reproducible)~
- [x] For kernel packages only: source tarball uploaded internally
