### PR TITLE
Commit Tor debs on trixie

### DIFF
--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -17,7 +17,7 @@ jobs:
             run: |
               apt-get update && apt-get install --yes reprepro ca-certificates dctrl-tools \
                 git git-lfs openssh-client python3 gh
-                
+
           - uses: actions/checkout@v6
             with:
               lfs: true
@@ -46,8 +46,10 @@ jobs:
               # Copy the new packages over, intentionally leaving the old ones around
               cp repo/public/pool/main/t/tor/*noble*.deb core/noble/
               cp repo/public/pool/main/t/tor/*bookworm*.deb workstation/bookworm/
+              cp repo/public/pool/main/t/tor/*trixie*.deb workstation/trixie/
               git add core/noble/*.deb
               git add workstation/bookworm/*.deb
+              git add workstation/trixie/*.deb
               # If there are staged changes, git diff will fail, so we commit and push
               git diff --staged --exit-code || (git commit -m "Automatically updating Tor packages" \
                   && git push https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git main \


### PR DESCRIPTION
The update workflow was already setup in reprepro, we just weren't committing the fetched debs.

Fixes <https://github.com/freedomofpress/securedrop-client/issues/3484>.

## Test plan

visual review is sufficient