### PR TITLE
Add paxctld 1.2.8-1 for trixie

### DIFF
--- a/workstation/trixie/paxctld_1.2.8-1_amd64.deb
+++ b/workstation/trixie/paxctld_1.2.8-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41a78505d692936c06d41daa1c136a365116a4efa9dfe04d2a2d5acf5d305417
+size 279234


### PR DESCRIPTION
```
$ wget https://grsecurity.net/paxctld/paxctld_1.2.8-1_amd64.deb{,.sig}
Saving 'paxctld_1.2.8-1_amd64.deb'
Saving 'paxctld_1.2.8-1_amd64.deb.sig'

$ gpg --verify paxctld_1.2.8-1_amd64.deb{.sig,}
gpg: Signature made Fri Oct  3 10:43:36 2025 EDT
gpg:                using RSA key DE9452CE46F42094907F108B44D1C0F82525FE49
gpg: Good signature from "Bradley Spengler (spender) <spender@grsecurity.net>" [unknown]
gpg:                 aka "Bradley Spengler <brad.spengler@grsecurity.net>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: DE94 52CE 46F4 2094 907F  108B 44D1 C0F8 2525 FE49
```
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1709>.

## Checklist
- [x] Verify matches what you can grab from https://grsecurity.net/download
- [x] .buildinfo saved in https://github.com/freedomofpress/build-logs/commit/344373935043ab5447538578b63690c8cf83e473
