### PR TITLE
Add 2.16.0 packages

### DIFF
--- a/core/noble/securedrop-app-code-dbgsym_2.16.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code-dbgsym_2.16.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7ce494d97dac60a405efa222c68e6db6382762549b60e2cf33e302b376d7893
+size 1029826

--- a/core/noble/securedrop-app-code_2.16.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-app-code_2.16.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdd553ea3e76ca4e318f5f23f2c312b5dfb1c8612ff8cd5bb898b6b20f5de50d
+size 14482950

--- a/core/noble/securedrop-config_2.16.0~rc1+noble_amd64.deb
+++ b/core/noble/securedrop-config_2.16.0~rc1+noble_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52f8a5471101901fa5296409deb5c5e61ab2699124fb5068d1ff2c905b479ab0
+size 6690

--- a/core/noble/securedrop-keyring_0.2.2+2.16.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-keyring_0.2.2+2.16.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e14c88746d4fe1edc4d6919d3f720f3f9a74afdd89280a61fb803493b9a8bac
+size 7562

--- a/core/noble/securedrop-ossec-agent_3.6.0+2.16.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-agent_3.6.0+2.16.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0ec5d0f378d1af36b3579731af61579d791ad9ac4f02150b7096becfcf56f5f
+size 5242

--- a/core/noble/securedrop-ossec-server_3.6.0+2.16.0~rc1+noble_all.deb
+++ b/core/noble/securedrop-ossec-server_3.6.0+2.16.0~rc1+noble_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edd1e712aa052a57025b4f2c1f08fd712e39df9830baabf210d7e5f88a7c35e7
+size 9242

--- a/workstation/trixie/securedrop-admin-dbgsym_2.16.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-admin-dbgsym_2.16.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:063b3c4658c3b32056faeae87b53aa9fb6ccee725d2ba0a70eb4bdf673b5cf1a
+size 888220

--- a/workstation/trixie/securedrop-admin_2.16.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-admin_2.16.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70e056bf6070eddb7c900e2bf83f0f94638d8e5842b8976a2a794e0e9b3e8b8d
+size 25374912


### PR DESCRIPTION
## Status

Ready for review 
## Description of changes

## Checklist
- [ ] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/ac64e68e6021094a6427419af07b3d46aa883a28
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
