### PR TITLE
Add SecureDrop Inbox 1.4.0-rc1 packages

### DIFF
--- a/workstation/bookworm/securedrop-app_1.4.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-app_1.4.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f584e20db9e53f82d6e76e483844b37e69b2b0ce13d87a93eefa347c306567e8
+size 97372624

--- a/workstation/bookworm/securedrop-export_1.4.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-export_1.4.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9fbedc9045c6909feda6d6b0b403223d310bdc98abc601f18b4b0d046c15615
+size 1644020

--- a/workstation/bookworm/securedrop-gpg-config_1.4.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-gpg-config_1.4.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8820e3bbf80990442e9d5c3f911cb4587f1f294ad17a5106874647400bf1914
+size 5208

--- a/workstation/bookworm/securedrop-keyring_1.4.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-keyring_1.4.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b653523c5f9c4a6173f0768050e61f96b41cfbbd3e106772f0af72477635fd24
+size 10252

--- a/workstation/bookworm/securedrop-log_1.4.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-log_1.4.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:035112a48e007b7b8a9c9e86ef70f9abad0df51cc9abb6467c23368d48000f5f
+size 1612364

--- a/workstation/bookworm/securedrop-proxy-dbgsym_1.4.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy-dbgsym_1.4.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f0f9a453dc40c8c15daeb217c4baf3d68f5e0b4b038653d00068891e1f9a985
+size 12353272

--- a/workstation/bookworm/securedrop-proxy_1.4.0~rc1+bookworm_amd64.deb
+++ b/workstation/bookworm/securedrop-proxy_1.4.0~rc1+bookworm_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94404672814c565c0d7662c94167ad32bf99accc710299dbff87b61efa7e22f8
+size 1042184

--- a/workstation/bookworm/securedrop-workstation-config_1.4.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-config_1.4.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:005a8a2df9f345805b53926705717c4d3afbac2e8ed791ebdad2d2d94b1f5421
+size 9324

--- a/workstation/bookworm/securedrop-workstation-viewer_1.4.0~rc1+bookworm_all.deb
+++ b/workstation/bookworm/securedrop-workstation-viewer_1.4.0~rc1+bookworm_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51be1cf508c88a6a6c45c3dc31112dec2b704107100820587bb15691a6313d0e
+size 3976


### PR DESCRIPTION
## Checklist
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/e3f0b6483610b88e3d972f8fae5e8c5215723ce4
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
