### PR TITLE
adding 6.18.35 kernels for workstation debian-13 VMs

### DIFF
--- a/workstation/trixie/linux-headers-6.18.35-1-grsec-workstation_6.18.35-1-grsec-workstation-1_amd64.deb
+++ b/workstation/trixie/linux-headers-6.18.35-1-grsec-workstation_6.18.35-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b88ab8150d9bca39fc99402fab8a3f53e3f255c78116cc7b0a28fc0c08303dad
+size 27850880

--- a/workstation/trixie/linux-image-6.18.35-1-grsec-workstation_6.18.35-1-grsec-workstation-1_amd64.deb
+++ b/workstation/trixie/linux-image-6.18.35-1-grsec-workstation_6.18.35-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09a6b988658418ec6b4fc0ef0e8e7f920af3492ba484c03900970000624e1fa7
+size 61091364

--- a/workstation/trixie/securedrop-workstation-grsec_6.18.35-1-grsec-workstation-1_amd64.deb
+++ b/workstation/trixie/securedrop-workstation-grsec_6.18.35-1-grsec-workstation-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e4d8ce1e0507edea83e4e768afb7a633dbda4b7642838140d03e2d33068d516
+size 2064


### PR DESCRIPTION
## Status

Ready for review 

## Description of changes

## Checklist
- [x] Build metadata has been committed to https://github.com/freedomofpress/build-logs/commit/ce5c32e3ce2a5e650486ec8efce6f65c739f2e0e
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)
- [x] For kernel packages only: source tarball uploaded internally
