### PR TITLE
Add SecureDrop Inbox 1.5.0-rc1 packages

### DIFF
--- a/workstation/trixie/securedrop-app_1.5.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-app_1.5.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa3aa623810a43a5608d46ba98e4ebcc7a7c3a18b7dfde9814a68c3b215b13c4
+size 97371780

--- a/workstation/trixie/securedrop-export_1.5.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-export_1.5.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49f4bfbc7e5ecb9af44eb228037d7beb369568861fa7cc7731d3b1b00ad1f15a
+size 1079748

--- a/workstation/trixie/securedrop-gpg-config_1.5.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-gpg-config_1.5.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ad5f6c93379f6a7bc5a99514f789d048ecf3df9e16c72bbd95551f1a35abb88
+size 5348

--- a/workstation/trixie/securedrop-keyring_1.5.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-keyring_1.5.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:396b93f03df553cdb6c07e98fa0dee2812ecef61911a9debdc2222c428610868
+size 10264

--- a/workstation/trixie/securedrop-log_1.5.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-log_1.5.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbbf7f192bbf195b5de4bbf9965871cea5d2329e4cca9b967361133910808143
+size 1006180

--- a/workstation/trixie/securedrop-proxy-dbgsym_1.5.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-proxy-dbgsym_1.5.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4fb3604e3c9045742c5af1a451bcd94e43c520ec347d988cf72fed3a216abba
+size 12332340

--- a/workstation/trixie/securedrop-proxy_1.5.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-proxy_1.5.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a00c87c4e08d7dbb2f4cfbbd435c1f6e22fee43b43424b1c58619faf3dee3b11
+size 1041792

--- a/workstation/trixie/securedrop-workstation-config_1.5.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-workstation-config_1.5.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:911700c33089c75cb8fa248fd86fb4b7fa71d24e880f638107c294cb97a9f5ff
+size 9332

--- a/workstation/trixie/securedrop-workstation-viewer_1.5.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-workstation-viewer_1.5.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94bcf9b72294732d21bc5f179c7cf3213a511eab41ffa5e8cf14b8bcc1103e0e
+size 3996


### PR DESCRIPTION

## Description of changes

Note these are trixie packages! And are in the trixie folder, not bookworm :)

## Checklist
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs).: https://github.com/freedomofpress/build-logs/commit/8632f8074a57fd6bc1f946df1768c4a9a9186de6
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)

