### PR TITLE
Add SecureDrop Inbox 1.5.0-rc2 packages

### DIFF
--- a/workstation/trixie/securedrop-app_1.5.0~rc2+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-app_1.5.0~rc2+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a746391fdf8192e95a2d41312d1fcf6a48f7997c9dbb54f058a9fba15f71062f
+size 97358200

--- a/workstation/trixie/securedrop-export_1.5.0~rc2+trixie_all.deb
+++ b/workstation/trixie/securedrop-export_1.5.0~rc2+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f9f9f01866bf70b2676f3119108b81600ad8e6fe25d815c1e7b080e87e0e3c2
+size 1079672

--- a/workstation/trixie/securedrop-gpg-config_1.5.0~rc2+trixie_all.deb
+++ b/workstation/trixie/securedrop-gpg-config_1.5.0~rc2+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c400dcdaf135e850a5b0f052e2f25ad80fc816d95bb6f7be633ac157cfe94da5
+size 5360

--- a/workstation/trixie/securedrop-keyring_1.5.0~rc2+trixie_all.deb
+++ b/workstation/trixie/securedrop-keyring_1.5.0~rc2+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21d58ccbf90fb6d9874d6fc729edb02a6872f71401f40816d58d272cd2491af4
+size 10276

--- a/workstation/trixie/securedrop-log_1.5.0~rc2+trixie_all.deb
+++ b/workstation/trixie/securedrop-log_1.5.0~rc2+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cb2c13d30411a8f58bff0f38e058961561365f5e923669c239a940dccc90caf
+size 1005752

--- a/workstation/trixie/securedrop-proxy-dbgsym_1.5.0~rc2+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-proxy-dbgsym_1.5.0~rc2+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1fc50da661bd0b5a3adbb3e639dc19d8b6ad86665cf8f065eebf0ce8493a96b
+size 12332344

--- a/workstation/trixie/securedrop-proxy_1.5.0~rc2+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-proxy_1.5.0~rc2+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:242e22348cc1cd789b2c1ae5b1ef3614c15df63eeb3937c704e007da0ab0e15d
+size 1041524

--- a/workstation/trixie/securedrop-workstation-config_1.5.0~rc2+trixie_all.deb
+++ b/workstation/trixie/securedrop-workstation-config_1.5.0~rc2+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b7ed34f6afc0b74656a1954160d1391763364ddffb8991724a3cb3ce825efbc
+size 9348

--- a/workstation/trixie/securedrop-workstation-viewer_1.5.0~rc2+trixie_all.deb
+++ b/workstation/trixie/securedrop-workstation-viewer_1.5.0~rc2+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbedeb7ec0b8d1a96c220906b8382b6092179452a99ad52749b2f3ecfdac8c81
+size 4004


### PR DESCRIPTION
## Description of changes

## Checklist
- [ ] Tag in repository is correct: https://github.com/freedomofpress/securedrop-client/releases/tag/1.5.0-rc2
- [ ] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/bc3c9e1baa3369fd4fc457201dc0e925d308de56
- [ ] Ensure packages names are the ones expected (i.e. no missing packages)
- [ ] Build locally and compare sha256sum hashes (if reproducible)

