### PR TITLE
add SecureDrop 1.6.0-rc1 packages

### DIFF
--- a/workstation/trixie/securedrop-app_1.6.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-app_1.6.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab32fdf6bb9cd4b7af67069920b78454b818aaf32806fc3e27f5904375f2a4e5
+size 97689912

--- a/workstation/trixie/securedrop-export_1.6.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-export_1.6.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85b11709a911842791d383f94c55357e6d7d91d98a03b404db53147537ce97d9
+size 1079564

--- a/workstation/trixie/securedrop-gpg-config_1.6.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-gpg-config_1.6.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f235de28e58f0a997cd079be388a104483a512944a7b61c52e9f40c9c1441c31
+size 5376

--- a/workstation/trixie/securedrop-keyring_1.6.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-keyring_1.6.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40653f1d672953efe068730231d4cf6b1359ec154a6e214748d72a2069fda210
+size 10292

--- a/workstation/trixie/securedrop-log_1.6.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-log_1.6.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52bba6a8a26594fa634a108d901253b20f61d8eb6e5e89de11493dd7bab9c2fe
+size 1005728

--- a/workstation/trixie/securedrop-proxy-dbgsym_1.6.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-proxy-dbgsym_1.6.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bfb47f8257bfa8186289d74fff74dc6675d810f03f12a74d21b6e05107fa87e
+size 16502336

--- a/workstation/trixie/securedrop-proxy_1.6.0~rc1+trixie_amd64.deb
+++ b/workstation/trixie/securedrop-proxy_1.6.0~rc1+trixie_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ac4280a9dd69bd5132ef27a37343d90dd8da6904a7d5894938a1a54b87c0d5
+size 1410396

--- a/workstation/trixie/securedrop-workstation-config_1.6.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-workstation-config_1.6.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7c3fe74f0b471b9ebb14c25af8d6ae4cee6c0c9cd18c88ea74593ffb4dab0f
+size 9360

--- a/workstation/trixie/securedrop-workstation-viewer_1.6.0~rc1+trixie_all.deb
+++ b/workstation/trixie/securedrop-workstation-viewer_1.6.0~rc1+trixie_all.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24fe7dcefdbb9ae9553ac8906e83961b1e5f028f53ac9940cdb95cbd92c006ef
+size 4024


### PR DESCRIPTION
## Checklist
- [x] Tag in repository is correct: https://github.com/freedomofpress/securedrop-client/releases/tag/1.6.0-rc1
- [x] Build metadata has been committed to [build-logs](https://github.com/freedomofpress/build-logs): https://github.com/freedomofpress/build-logs/commit/536a41b6e4c48da9c9cf07eebf2abae954e42f50
- [x] Ensure packages names are the ones expected (i.e. no missing packages)
- [x] Build locally and compare sha256sum hashes (if reproducible)
- [ ] For kernel packages only: source tarball uploaded internally
